### PR TITLE
Configure parallelization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,3 +41,6 @@ Style/RaiseArgs:
 Style/Documentation:
   Exclude:
     - lib/code_keeper.rb # Does not need documentation.
+
+Metrics/AbcSize:
+  Max: 25

--- a/lib/code_keeper/config.rb
+++ b/lib/code_keeper/config.rb
@@ -3,10 +3,11 @@
 module CodeKeeper
   # Provide configuration
   class Config
-    attr_accessor :metrics
+    attr_accessor :metrics, :number_of_threads
 
     def initialize
       @metrics = [:cyclomatic_complexity]
+      @number_of_threads = 2
     end
   end
 end

--- a/lib/code_keeper/scorer.rb
+++ b/lib/code_keeper/scorer.rb
@@ -8,10 +8,21 @@ module CodeKeeper
         result = CodeKeeper::Result.new
         metrics = result.scores.keys
         ruby_file_paths = Finder.new(paths).file_paths
+        num_threads = CodeKeeper.config.number_of_threads
 
-        Parallel.map(ruby_file_paths, in_threads: 2) do |path|
-          metrics.each do |metric|
-            result.add(:cyclomatic_complexity, path, ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score)
+        # NOTE: If the configuration says no concurrent execution, the parallel gem is not used.
+        # `in_threads: 1` makes 2 threads, a sleep_forever thread and the main thread.
+        if num_threads == 1
+          ruby_file_paths.each do |path|
+            metrics.each do |metric|
+              result.add(:cyclomatic_complexity, path, ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score)
+            end
+          end
+        else
+          Parallel.map(ruby_file_paths, in_threads: num_threads) do |path|
+            metrics.each do |metric|
+              result.add(:cyclomatic_complexity, path, ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score)
+            end
           end
         end
 


### PR DESCRIPTION
Enable users to configure concurrency.

If the value is
- equal to 1, it's executed sequentially.
- more than 1, it's executed in parallel.

Also in this PR, the ABC size limit is loosen.