### PR TITLE
Add the class length metric

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,16 @@ Style/Documentation:
 
 Metrics/AbcSize:
   Max: 25
+  Exclude:
+    # It's hard to control.
+    - lib/code_keeper/metrics/class_length.rb
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    # It's hard to control.
+    - lib/code_keeper/metrics/class_length.rb 
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    # It's hard to control.
+    - lib/code_keeper/metrics/class_length.rb 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The CodeKeeper measures metrics especially about complexity and size of Ruby fil
 
 Mesuring metrics leads to keep codebase simple and clean, and I name the gem CodeKeeper.
 
-Now CodeKeeper supports the cyclomatic complexity. The scores are output to stdout.
+Now CodeKeeper supports the cyclomatic complexity of a file, the ABC software metric of a file, and class length. The scores are output to stdout.
 
 ## Installation
 

--- a/lib/code_keeper.rb
+++ b/lib/code_keeper.rb
@@ -11,6 +11,7 @@ require 'code_keeper/scorer'
 require 'code_keeper/result'
 require 'code_keeper/metrics'
 require 'code_keeper/metrics/cyclomatic_complexity'
+require 'code_keeper/metrics/class_length'
 
 module CodeKeeper
   class << self

--- a/lib/code_keeper/config.rb
+++ b/lib/code_keeper/config.rb
@@ -6,7 +6,7 @@ module CodeKeeper
     attr_accessor :metrics, :number_of_threads
 
     def initialize
-      @metrics = [:cyclomatic_complexity]
+      @metrics = [:cyclomatic_complexity, :class_length, :abc_metric]
       @number_of_threads = 2
     end
   end

--- a/lib/code_keeper/config.rb
+++ b/lib/code_keeper/config.rb
@@ -6,7 +6,7 @@ module CodeKeeper
     attr_accessor :metrics, :number_of_threads
 
     def initialize
-      @metrics = [:cyclomatic_complexity, :class_length, :abc_metric]
+      @metrics = %i[cyclomatic_complexity class_length abc_metric]
       @number_of_threads = 2
     end
   end

--- a/lib/code_keeper/formatter.rb
+++ b/lib/code_keeper/formatter.rb
@@ -10,10 +10,16 @@ module CodeKeeper
 
         result.scores.each_key do |metric|
           result.scores[metric].each do |k, v|
+            klass_or_file_key = if metric == :class_length
+                                  'Class'
+                                else
+                                  'Filename'
+                                end
+
             formatted_result.concat(
               <<~EOS
                 Metric: #{metric}
-                Filename: #{k}
+                #{klass_or_file_key}: #{k}
                 Score: #{v}
                 ---
               EOS

--- a/lib/code_keeper/metrics.rb
+++ b/lib/code_keeper/metrics.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require 'code_keeper/metrics/abc_metric'
 require 'code_keeper/metrics/cyclomatic_complexity'
+require 'code_keeper/metrics/class_length'
 
 module CodeKeeper
   # Manage config values of metrics and the correspond classes
   module Metrics
-    MAPPINGS = { cyclomatic_complexity: CodeKeeper::Metrics::CyclomaticComplexity }.freeze
+    MAPPINGS = {
+      abc_metric: CodeKeeper::Metrics::AbcMetric,
+      cyclomatic_complexity: CodeKeeper::Metrics::CyclomaticComplexity,
+      class_length: CodeKeeper::Metrics::ClassLength
+    }.freeze
   end
 end

--- a/lib/code_keeper/metrics/abc_metric.rb
+++ b/lib/code_keeper/metrics/abc_metric.rb
@@ -9,6 +9,7 @@ module CodeKeeper
 
       def initialize(file_path)
         ps = Parser.parse(file_path)
+        @path = file_path
         @body = ps.ast
         @assignments = 0
         @branches = 0
@@ -22,7 +23,8 @@ module CodeKeeper
         @conditionals = caluculator.instance_variable_get('@condition')
         @branches = caluculator.instance_variable_get('@branch')
 
-        Math.sqrt(@assignments**2 + @branches**2 + @conditionals**2).round(4)
+        value = Math.sqrt(@assignments**2 + @branches**2 + @conditionals**2).round(4)
+        { "#{@path}": value }
       end
     end
   end

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -2,7 +2,7 @@
 
 module CodeKeeper
   module Metrics
-    # Caluculate Method Length.
+    # Caluculate Class Length.
     class ClassLength
       def initialize(file_path)
         @ps = Parser.parse(file_path)

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module CodeKeeper
+  module Metrics
+    # Caluculate Method Length.
+    class ClassLength
+      def initialize(file_path)
+        @ps = Parser.parse(file_path)
+        @body = @ps.ast
+        @score_hash = {}
+      end
+
+      # NOTE: This doesn't exclude foldale sources like Array, Hash and Heredoc.
+      def score
+        @body.each_node(:class, :casgn) do |node|
+          if node.class_type?
+            @score_hash.store(node.loc.name.source.to_sym, calculate(node))
+          elsif node.casgn_type?
+            parent = node.parent
+
+            if parent&.assignment?
+              block_node = node.children[2]
+            elsif parent&.parent&.masgn_type?
+              # In the case where `A, B = Struct.new(:a, :b)`,
+              # B is always nil.
+              assigned = parent.loc.expression.source.split(',').first
+              next unless node.loc.name.source == assigned
+
+              block_node = parent.parent.children[1]
+            else
+              _scope, klass, block_node = *node
+            end
+
+            # This is not to raise error on dynamic assignments like `X = Y = Z = Class.new`.
+            # the block node is as follows if node is X:
+            # `s(:casgn, nil, :Y, s(:casgn, nil, :Z, s(:block, ...`
+            # Similarly the block node is `:X` as follows if node is Y.
+            next unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
+
+
+            # if the parent is an assignment_type or the parent of the parent is a masgn_type,
+            klass ||= node.loc.name.source.to_sym
+
+            @score_hash.store(klass, calculate(block_node))
+          end
+        end
+        @score_hash
+      end
+
+      private
+
+      def calculate(node)
+        # node.body.line_count doesn't include comments after definition of a class.
+        count = node.nonempty_line_count - 2
+        count - line_count_of_inner_nodes(node) - comment_line_count(node)
+      end
+
+      def line_count_of_inner_nodes(node)
+        count = 0
+        node.each_descendant(:class, :module) do |klass_or_module_node|
+          count += klass_or_module_node.nonempty_line_count
+        end
+        count
+      end
+
+      def comment_line_count(node)
+        count = 0
+        @ps.comments.each do |comment|
+          count += 1 if (node.first_line...node.last_line).include? comment.loc.line
+        end
+        count
+      end
+    end
+  end
+end

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -37,7 +37,6 @@ module CodeKeeper
             # Similarly the block node is `:X` as follows if node is Y.
             next unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
 
-
             # if the parent is an assignment_type or the parent of the parent is a masgn_type,
             klass ||= node.loc.name.source.to_sym
 

--- a/lib/code_keeper/metrics/cyclomatic_complexity.rb
+++ b/lib/code_keeper/metrics/cyclomatic_complexity.rb
@@ -10,18 +10,20 @@ module CodeKeeper
       CONSIDERED_NODES = %i[if while until for csend block block_pass rescue when and or or_asgnand_asgn].freeze
 
       def initialize(file_path)
-        ps = Parser.parse(file_path)
+        @path = file_path
+        ps = Parser.parse(@path)
         @body = ps.ast
       end
 
       # returns score of cyclomatic complexity
       def score
-        @body.each_node(:lvasgn, *CONSIDERED_NODES).reduce(1) do |score, node|
+        final_score = @body.each_node(:lvasgn, *CONSIDERED_NODES).reduce(1) do |score, node|
           next score if !iterating_block?(node) || node.lvasgn_type?
           next score if node.csend_type? && discount_for_repeated_csend?(node)
 
           next 1 + score
         end
+        { "#{@path}": final_score }
       end
     end
   end

--- a/lib/code_keeper/result.rb
+++ b/lib/code_keeper/result.rb
@@ -9,8 +9,8 @@ module CodeKeeper
       @scores = CodeKeeper.config.metrics.map { |key| [key, {}] }.to_h
     end
 
-    def add(metric, path, score)
-      scores[:"#{metric}"].store(path, score)
+    def add(metric, klass_or_path, score)
+      scores[:"#{metric}"].store(klass_or_path, score)
     end
   end
 end

--- a/lib/code_keeper/scorer.rb
+++ b/lib/code_keeper/scorer.rb
@@ -15,13 +15,23 @@ module CodeKeeper
         if num_threads == 1
           ruby_file_paths.each do |path|
             metrics.each do |metric|
-              result.add(:cyclomatic_complexity, path, ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score)
+              score = ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score
+
+              # The class length metric's score has multiple classes.
+              score.each do |k, v|
+                result.add(metric, k.to_s, v)
+              end
             end
           end
         else
           Parallel.map(ruby_file_paths, in_threads: num_threads) do |path|
             metrics.each do |metric|
-              result.add(:cyclomatic_complexity, path, ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score)
+              score = ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score
+
+              # The class length metric's score has multiple classes.
+              score.each do |k, v|
+                result.add(metric, k.to_s, v)
+              end
             end
           end
         end

--- a/lib/code_keeper/scorer.rb
+++ b/lib/code_keeper/scorer.rb
@@ -14,29 +14,26 @@ module CodeKeeper
         # `in_threads: 1` makes 2 threads, a sleep_forever thread and the main thread.
         if num_threads == 1
           ruby_file_paths.each do |path|
-            metrics.each do |metric|
-              score = ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score
-
-              # The class length metric's score has multiple classes.
-              score.each do |k, v|
-                result.add(metric, k.to_s, v)
-              end
-            end
+            metrics.each { |metric| calculate_score(metric, path, result) }
           end
         else
           Parallel.map(ruby_file_paths, in_threads: num_threads) do |path|
-            metrics.each do |metric|
-              score = ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score
-
-              # The class length metric's score has multiple classes.
-              score.each do |k, v|
-                result.add(metric, k.to_s, v)
-              end
-            end
+            metrics.each { |metric| calculate_score(metric, path, result) }
           end
         end
 
         result
+      end
+
+      private
+
+      def calculate_score(metric, path, result)
+        score = ::CodeKeeper::Metrics::MAPPINGS[metric].new(path).score
+
+        # The class length metric's score has multiple classes.
+        score.each do |k, v|
+          result.add(metric, k.to_s, v)
+        end
       end
     end
   end

--- a/spec/code_keeper/cli_spec.rb
+++ b/spec/code_keeper/cli_spec.rb
@@ -2,6 +2,12 @@
 
 RSpec.describe CodeKeeper::Cli do
   describe '.run' do
+    before do
+      CodeKeeper.configure do |config|
+        config.metrics = [:cyclomatic_complexity]
+      end
+    end
+
     context 'normal cases' do
       it 'outputs scores to stdout' do
         expected_output = <<~EOS

--- a/spec/code_keeper/formatter_spec.rb
+++ b/spec/code_keeper/formatter_spec.rb
@@ -19,8 +19,12 @@ RSpec.describe CodeKeeper::Formatter do
       end
 
       before do
+        CodeKeeper.configure do |config|
+          config.metrics = [:cyclomatic_complexity]
+        end
+
         @result = CodeKeeper::Result.new
-        @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb', 2)
+        
         @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/target_sample.rb', 1)
       end
 
@@ -46,6 +50,10 @@ RSpec.describe CodeKeeper::Formatter do
       end
 
       before do
+        CodeKeeper.configure do |config|
+          config.metrics = [:class_length]
+        end
+
         @result = CodeKeeper::Result.new
         @result.add(:class_length, 'SimpleClass', 2)
         @result.add(:class_length, 'NameSpaceClass', 3)

--- a/spec/code_keeper/formatter_spec.rb
+++ b/spec/code_keeper/formatter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CodeKeeper::Formatter do
         end
 
         @result = CodeKeeper::Result.new
-        
+        @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb', 2)
         @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/target_sample.rb', 1)
       end
 

--- a/spec/code_keeper/formatter_spec.rb
+++ b/spec/code_keeper/formatter_spec.rb
@@ -2,29 +2,58 @@
 
 RSpec.describe CodeKeeper::Formatter do
   describe '.format' do
-    let(:expected_string) do
-      <<~EOS
-  Scores:
+    context 'it shows a filename' do
+      let(:expected_string) do
+        <<~EOS
+          Scores:
 
-  Metric: cyclomatic_complexity
-  Filename: /foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb
-  Score: 2
-  ---
-  Metric: cyclomatic_complexity
-  Filename: /foo/bar/code_keeper/spec/fixtures/target_sample.rb
-  Score: 1
-  ---
-      EOS
+          Metric: cyclomatic_complexity
+          Filename: /foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb
+          Score: 2
+          ---
+          Metric: cyclomatic_complexity
+          Filename: /foo/bar/code_keeper/spec/fixtures/target_sample.rb
+          Score: 1
+          ---
+        EOS
+      end
+
+      before do
+        @result = CodeKeeper::Result.new
+        @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb', 2)
+        @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/target_sample.rb', 1)
+      end
+
+      it 'returns an string' do
+        expect(CodeKeeper::Formatter.format(@result)).to eq expected_string
+      end
     end
 
-    before do
-      @result = CodeKeeper::Result.new
-      @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb', 2)
-      @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/target_sample.rb', 1)
-    end
+    context 'it shows a class name' do
+      let(:expected_string) do
+        <<~EOS
+          Scores:
 
-    it 'returns an string' do
-      expect(CodeKeeper::Formatter.format(@result)).to eq expected_string
+          Metric: class_length
+          Class: SimpleClass
+          Score: 2
+          ---
+          Metric: class_length
+          Class: NameSpaceClass
+          Score: 3
+          ---
+        EOS
+      end
+
+      before do
+        @result = CodeKeeper::Result.new
+        @result.add(:class_length, 'SimpleClass', 2)
+        @result.add(:class_length, 'NameSpaceClass', 3)
+      end
+
+      it 'returns an string' do
+        expect(CodeKeeper::Formatter.format(@result)).to eq expected_string
+      end
     end
   end
 end

--- a/spec/code_keeper/metrics/abc_metric_spec.rb
+++ b/spec/code_keeper/metrics/abc_metric_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe CodeKeeper::Metrics::AbcMetric do
   describe "#score" do
-    it "returns 3.7417, which is the four decimal point" do
+    it "returns a hash of a filename and a score, 3.7417, which is the four decimal point" do
+      expected_hash = { 'spec/fixtures/branch_in_loop.rb': 3.7417 }
       abc_metric = CodeKeeper::Metrics::AbcMetric.new('spec/fixtures/branch_in_loop.rb')
-      expect(abc_metric.score).to eq 3.7417
+      expect(abc_metric.score).to eq expected_hash
     end
   end
 end

--- a/spec/code_keeper/metrics/class_length_spec.rb
+++ b/spec/code_keeper/metrics/class_length_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe CodeKeeper::Metrics::ClassLength do
+  describe "#score" do
+    # This context also has a view of testing counting a comment just after class definition precisely.
+    context 'A file has one class, in which there is a comment, an empty line' do
+      it 'returns a hash with the value 1' do
+        cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/simple_class.rb')
+        expect(cl.score).to eq({ SimpleClass: 2 })
+      end
+    end
+
+    context 'A file has 3 classes, which are a namespace class and a inner class, and a class in a namespace module' do
+      it 'returns a hash with scores of 3 classes' do
+        expected_hash = { NameSpaceClass: 4, A: 2, B: 3 }
+        cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/namespace.rb')
+        expect(cl.score).to eq(expected_hash)
+      end
+    end
+
+    context 'A file has a class defined by overlapping constant assignments' do
+      it 'returns a hash with a score of the class C' do
+        expected_hash = { C: 2 }
+        cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/overlapping_const_assignments.rb')
+        expect(cl.score).to eq(expected_hash)
+      end
+    end
+
+    context 'A file has 2 classes defined by a singleton class' do
+      it 'returns a hash with scores of 2 classes' do
+        expected_hash = { A: 3, B: 2 }
+        cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/singleton.rb')
+        expect(cl.score).to eq(expected_hash)
+      end
+    end
+
+    context 'A file has 2 classes defined by a Struct object, one of which is a multiple assignment' do
+      it 'returns a hash with scores of 2 classes' do
+        expected_hash = { A: 2, B: 3 }
+        cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/struct.rb')
+        expect(cl.score).to eq(expected_hash)
+      end
+    end
+  end
+end

--- a/spec/code_keeper/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/code_keeper/metrics/cyclomatic_complexity_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe CodeKeeper::Metrics::CyclomaticComplexity do
   describe "#score" do
-    it "returns 2" do
+    it 'returns a hash with score of a file' do
+      expected_hash = { 'spec/fixtures/branch_in_loop.rb': 2 }
       complexity = CodeKeeper::Metrics::CyclomaticComplexity.new('spec/fixtures/branch_in_loop.rb')
-      expect(complexity.score).to eq 2
+      expect(complexity.score).to eq expected_hash
     end
   end
 end

--- a/spec/fixtures/class_samples/namespace.rb
+++ b/spec/fixtures/class_samples/namespace.rb
@@ -1,0 +1,20 @@
+class NameSpaceClass
+  class A
+    a = 1
+    a = 2
+  end
+
+  # This is NameSpaceClass's field.
+  n = 1
+  n = 2
+  n = 3
+  n = 4
+end
+
+module NameSpaceModule
+  class B
+    b = 1
+    b = 2
+    b = 3
+  end
+end

--- a/spec/fixtures/class_samples/overlapping_const_assignments.rb
+++ b/spec/fixtures/class_samples/overlapping_const_assignments.rb
@@ -1,0 +1,7 @@
+  A = B = C = Class.new do
+  # comment
+  c = 1
+
+  # comment
+  c = 2
+end

--- a/spec/fixtures/class_samples/simple_class.rb
+++ b/spec/fixtures/class_samples/simple_class.rb
@@ -1,0 +1,8 @@
+class SimpleClass
+  # Two lines of comments are to check if it's really able to count lines of comments precisely.
+  # To remove `class XXX` and `end`, two lines, using `node.body` doesn't count the first comment just after the `class XXX`
+  a = 1
+
+  # comment4
+  a = 2
+end

--- a/spec/fixtures/class_samples/singleton.rb
+++ b/spec/fixtures/class_samples/singleton.rb
@@ -1,0 +1,13 @@
+A = Class.new do
+  # comment
+  a = 1
+  a = 2
+
+  # comment
+  a = 3
+end
+
+B = ::Class.new do
+  b = 1
+  b = 2
+end

--- a/spec/fixtures/class_samples/struct.rb
+++ b/spec/fixtures/class_samples/struct.rb
@@ -1,0 +1,14 @@
+A = Struct.new(:a) do
+  # comment
+  # comment
+  a = 1
+
+  # comment
+  a = 2
+end
+
+B, C = Struct.new(:b, :c) do
+  b = 1
+  b = 2
+  c = 3
+end


### PR DESCRIPTION
Supported:
- skip comments
- skip empty lines

Not supported:
- Count a foldable source like Array, Hash and Heredoc as one line.

In this PR, I change the interface of `#score` because only `Metrics::ClassLength` knows a class name. The details is  in a commit message of 79cf515.