### PR TITLE
Support csv and json formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Unrelease
+- [#30](https://github.com/ebihara99999/code_keeper/pull/30): Support CSV and JSON format.
 
 ## 0.3.0 (2021-09-15)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The CodeKeeper measures metrics especially about complexity and size of Ruby fil
 
 Mesuring metrics leads to keep codebase simple and clean, and I name the gem CodeKeeper.
 
-Now CodeKeeper supports the cyclomatic complexity of a file, the ABC software metric of a file, and class length. The scores are output to stdout.
+Now CodeKeeper supports the cyclomatic complexity of a file, the ABC software metric of a file, and class length. The scores are output to stdout of a json or csv format.
 
 ## Installation
 
@@ -25,18 +25,11 @@ Or install it yourself as:
 Run CodeKeeper and you get scores of metrics from stdout like 
 
 ```rb
-$ bundle exec code_keeper ./app/models
-Scores:
-
-Metric: cyclomatic_complexity
-Filename: app/models/admin.rb
-Score: 1
----
-Metric: cyclomatic_complexity
-Filename: app/models/user.rb
-Score: 23
----
+$ bundle exec code_keeper app/models/user.rb app/models/admin.rb > metrics.json
+$ cat metrics.json
+{"cyclomatic_complexity":{"app/models/admin.rb":9,"app/models/user.rb":23},"class_length":{"Admin":86,"User":1475},"abc_metric":{"app/models/admin.rb":76.909,"app/models/user.rb":1546.4155}}
 ```
+If you need a csv format, change the configuration as explained later.
 
 ### Run CodeKeeper
 To measure metrics of all the ruby files recursively in the current directory, run
@@ -55,9 +48,11 @@ CodeKeeper makes you configure the following way:
 ```rb
 CodeKeeper.configure do |config|
   # If you choose metrics, specify as follows:
-  config.metrics = [:cyclomatic_complexity]
+  config.metrics = %i(cyclomatic_complexity abc_metric class_length)
   # The number of threads. The default is 2. Executed sequentially if you set 1.
   config.number_of_threads = 4
+  # The default is json
+  config.format = :json
 end
 ```
 

--- a/lib/code_keeper/config.rb
+++ b/lib/code_keeper/config.rb
@@ -3,11 +3,12 @@
 module CodeKeeper
   # Provide configuration
   class Config
-    attr_accessor :metrics, :number_of_threads
+    attr_accessor :metrics, :number_of_threads, :format
 
     def initialize
       @metrics = %i[cyclomatic_complexity class_length abc_metric]
       @number_of_threads = 2
+      @format = :json # json and csv are supported.
     end
   end
 end

--- a/lib/code_keeper/formatter.rb
+++ b/lib/code_keeper/formatter.rb
@@ -1,32 +1,24 @@
 # frozen_string_literal: true
+require 'csv'
 
 module CodeKeeper
   # Format a result and make it human-readable.
   class Formatter
     class << self
       def format(result)
-        title = "Scores:\n\n"
-        formatted_result = +title
+        return result.scores.to_json if CodeKeeper.config.format == :json
 
+        # csv is supported besides json
+        csv_array = []
         result.scores.each_key do |metric|
-          result.scores[metric].each do |k, v|
-            klass_or_file_key = if metric == :class_length
-                                  'Class'
-                                else
-                                  'Filename'
-                                end
-
-            formatted_result.concat(
-              <<~EOS
-                Metric: #{metric}
-                #{klass_or_file_key}: #{k}
-                Score: #{v}
-                ---
-              EOS
-            )
-          end
+          result.scores[metric].each { |k, v| csv_array << [metric, k, v] }
         end
-        formatted_result
+
+        headers = %w[metric file score]
+        CSV.generate(headers: true) do |csv|
+          csv << headers
+          csv_array.each { |array| csv << array }
+        end
       end
     end
   end

--- a/lib/code_keeper/formatter.rb
+++ b/lib/code_keeper/formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'csv'
 
 module CodeKeeper

--- a/spec/code_keeper/cli_spec.rb
+++ b/spec/code_keeper/cli_spec.rb
@@ -5,19 +5,13 @@ RSpec.describe CodeKeeper::Cli do
     before do
       CodeKeeper.configure do |config|
         config.metrics = [:cyclomatic_complexity]
+        config.format = :json
       end
     end
 
     context 'normal cases' do
       it 'outputs scores to stdout' do
-        expected_output = <<~EOS
-          Scores:
-
-          Metric: cyclomatic_complexity
-          Filename: ./spec/fixtures/branch_in_loop.rb
-          Score: 2
-          ---
-        EOS
+        expected_output = %({"cyclomatic_complexity":{"./spec/fixtures/branch_in_loop.rb":2}}\n)
 
         expect do
           CodeKeeper::Cli.run(['./spec/fixtures/branch_in_loop.rb'])

--- a/spec/code_keeper/formatter_spec.rb
+++ b/spec/code_keeper/formatter_spec.rb
@@ -2,64 +2,48 @@
 
 RSpec.describe CodeKeeper::Formatter do
   describe '.format' do
-    context 'it shows a filename' do
+    before do
+      CodeKeeper.configure do |config|
+        config.metrics = [:cyclomatic_complexity]
+      end
+
+      @result = CodeKeeper::Result.new
+      @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb', 2)
+      @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/target_sample.rb', 1)
+    end
+
+    context 'csv format' do
+      before do
+        CodeKeeper.configure do |config|
+          config.format = :csv
+        end
+      end
+
       let(:expected_string) do
         <<~EOS
-          Scores:
-
-          Metric: cyclomatic_complexity
-          Filename: /foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb
-          Score: 2
-          ---
-          Metric: cyclomatic_complexity
-          Filename: /foo/bar/code_keeper/spec/fixtures/target_sample.rb
-          Score: 1
-          ---
+         metric,file,score
+         cyclomatic_complexity,/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb,2
+         cyclomatic_complexity,/foo/bar/code_keeper/spec/fixtures/target_sample.rb,1
         EOS
       end
 
-      before do
-        CodeKeeper.configure do |config|
-          config.metrics = [:cyclomatic_complexity]
-        end
-
-        @result = CodeKeeper::Result.new
-        @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb', 2)
-        @result.add(:cyclomatic_complexity, '/foo/bar/code_keeper/spec/fixtures/target_sample.rb', 1)
-      end
-
-      it 'returns an string' do
+      it 'returns an csv string' do
         expect(CodeKeeper::Formatter.format(@result)).to eq expected_string
       end
     end
 
-    context 'it shows a class name' do
-      let(:expected_string) do
-        <<~EOS
-          Scores:
-
-          Metric: class_length
-          Class: SimpleClass
-          Score: 2
-          ---
-          Metric: class_length
-          Class: NameSpaceClass
-          Score: 3
-          ---
-        EOS
-      end
-
+    context 'json format' do
       before do
         CodeKeeper.configure do |config|
-          config.metrics = [:class_length]
+          config.format = :json
         end
-
-        @result = CodeKeeper::Result.new
-        @result.add(:class_length, 'SimpleClass', 2)
-        @result.add(:class_length, 'NameSpaceClass', 3)
       end
 
-      it 'returns an string' do
+      let(:expected_string) do
+        %({\"cyclomatic_complexity\":{\"/foo/bar/code_keeper/spec/fixtures/branch_in_loop.rb\":2,\"/foo/bar/code_keeper/spec/fixtures/target_sample.rb\":1}})
+      end
+
+      it 'returns an json string' do
         expect(CodeKeeper::Formatter.format(@result)).to eq expected_string
       end
     end


### PR DESCRIPTION
Measuring metrics regularly, it needs to store them into a database. Then csv or json format must be offered to users.