### PR TITLE
A result of the class_length doesn't show namespaces, and the class_length doesn't count comments of inner classes correctly.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,6 @@ Metrics/PerceivedComplexity:
   Exclude:
     # It's hard to control.
     - lib/code_keeper/metrics/class_length.rb 
+
+Metrics/MethodLength:
+  Max: 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Unrelease
+- [34](https://github.com/ebihara99999/code_keeper/pull/34): A result of the class_length doesn't show namespaces, and the class_length doesn't count comments of inner classes correctly.
 
 ## 0.5.0 (2021-09-16)
 ### Changes

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -40,9 +40,8 @@ module CodeKeeper
             # Similarly the block node is `:X` as follows if node is Y.
             next unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
 
-            # if the parent is an assignment_type or the parent of the parent is a masgn_type,
-            #klass ||= @klass_ns_mapping[node.loc.name.source.to_sym]
-
+            # NOTE: klass doesn't have a namespace.
+            # Only supports namepaces in `class A; end` case.
             if klass
               @score_hash.store(klass, calculate(block_node)) if klass
             else

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -20,7 +20,7 @@ module CodeKeeper
 
             if parent&.assignment?
               block_node = node.children[2]
-              klass = node.loc.name.source.to_sym
+              klass = node.loc.name.source
             elsif parent&.parent&.masgn_type?
               # In the case where `A, B = Struct.new(:a, :b)`,
               # B is always nil.
@@ -28,9 +28,10 @@ module CodeKeeper
               next unless node.loc.name.source == assigned
 
               block_node = parent.parent.children[1]
-              klass = node.loc.name.source.to_sym
+              klass = node.loc.name.source
             else
               _scope, klass, block_node = *node
+              klass = klass.to_s
             end
 
             # This is not to raise error on dynamic assignments like `X = Y = Z = Class.new`.

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -8,13 +8,16 @@ module CodeKeeper
         @ps = Parser.parse(file_path)
         @body = @ps.ast
         @score_hash = {}
+        @klass_ns_mapping = {}
       end
 
       # NOTE: This doesn't exclude foldale sources like Array, Hash and Heredoc.
       def score
-        @body.each_node(:class, :casgn) do |node|
-          if node.class_type?
-            @score_hash.store(node.loc.name.source.to_sym, calculate(node))
+        @body.each_node(:class, :casgn, :module) do |node|
+          build_namespace(node)
+          if node.class_type? || node.module_type?
+            _key = node.loc.name.source.to_sym
+            @score_hash.store(@klass_ns_mapping[_key], calculate(node))
           elsif node.casgn_type?
             parent = node.parent
 
@@ -28,7 +31,8 @@ module CodeKeeper
 
               block_node = parent.parent.children[1]
             else
-              _scope, klass, block_node = *node
+              _scope, klass_without_ns, block_node = *node
+              klass = @klass_ns_mapping[klass_without_ns.to_sym]
             end
 
             # This is not to raise error on dynamic assignments like `X = Y = Z = Class.new`.
@@ -38,7 +42,7 @@ module CodeKeeper
             next unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
 
             # if the parent is an assignment_type or the parent of the parent is a masgn_type,
-            klass ||= node.loc.name.source.to_sym
+            klass ||= @klass_ns_mapping[node.loc.name.source.to_sym]
 
             @score_hash.store(klass, calculate(block_node))
           end
@@ -56,18 +60,66 @@ module CodeKeeper
 
       def line_count_of_inner_nodes(node)
         count = 0
-        node.each_descendant(:class, :module) do |klass_or_module_node|
+        node.each_descendant(:class, :module).with_index do |klass_or_module_node, i|
+          # Doesn't count inner nodes of the first inner node.
+          # It's double counting.
+          break unless i.zero?
+
           count += klass_or_module_node.nonempty_line_count
         end
         count
       end
 
+      # Only counts the comment of the class or module of a node.
+      # Because `#line_count_of_inner_nodes` only considers the first inner node,
+      # the second or later inner nodes' commments are not necesarry to be counted.
       def comment_line_count(node)
-        count = 0
-        @ps.comments.each do |comment|
-          count += 1 if (node.first_line...node.last_line).include? comment.loc.line
+        node_range = node.first_line...node.last_line
+        comment_lines = @ps.comments.map { |comment| comment.loc.line }
+        descendant_class_lines = []
+        # A class may have multiple inner classes seperately.
+        # So it needs to store all descendant classes line ranges.
+        node.each_descendant(:class, :module) do |desendant|
+          # To make easier to compare and consider inner nodes, change array of line range into an array of line numbers.
+          descendant_class_lines << (desendant.first_line..desendant.last_line).to_a
         end
-        count
+
+        # To make easier to compare, change array of line range into an array of line numbers.
+        lines = descendant_class_lines.flatten.uniq
+
+        # The latter condition considers a class ouside or above the node.
+        comment_lines.select { |cl| !lines.include?(cl) && node_range.include?(cl) }.count
+      end
+
+      def build_namespace(node)
+        ns = node.children.first&.namespace&.source
+        self_name = if ns.nil?
+                      node.children.first&.short_name.to_s
+                    else
+                      node.children.first.namespace.source + "::#{node.children.first.short_name}"
+                    end
+
+        return if @klass_ns_mapping.key? self_name.to_sym
+
+        # The first class name has no namespace.
+        @klass_ns_mapping.store(self_name.to_sym, self_name)
+        name_with_ns = self_name.dup
+
+        # To build namepace, const_node is enough. Class_node has more information than necesarry.
+        # TODO This considers only nested classes. A class may have multiple classes seperately.
+        node.each_descendant(:const) do |cnode|
+          next unless cnode.parent.class_type? || cnode.parent.module_type?
+          next if cnode.short_name.to_s == self_name
+
+          ns = cnode.namespace&.source
+          child_class_name = if ns.nil?
+                               cnode.short_name
+                             else
+                               "#{cnode.namespace.source}::#{cnode.short_name}"
+                             end
+          name_with_ns = "#{name_with_ns}::#{child_class_name}"
+          @klass_ns_mapping.store(child_class_name, name_with_ns)
+        end
       end
     end
   end

--- a/lib/code_keeper/metrics/class_length.rb
+++ b/lib/code_keeper/metrics/class_length.rb
@@ -8,16 +8,14 @@ module CodeKeeper
         @ps = Parser.parse(file_path)
         @body = @ps.ast
         @score_hash = {}
-        @klass_ns_mapping = {}
       end
 
       # NOTE: This doesn't exclude foldale sources like Array, Hash and Heredoc.
       def score
         @body.each_node(:class, :casgn, :module) do |node|
-          build_namespace(node)
           if node.class_type? || node.module_type?
             _key = node.loc.name.source.to_sym
-            @score_hash.store(@klass_ns_mapping[_key], calculate(node))
+            @score_hash.store(build_namespace(node), calculate(node))
           elsif node.casgn_type?
             parent = node.parent
 
@@ -31,8 +29,7 @@ module CodeKeeper
 
               block_node = parent.parent.children[1]
             else
-              _scope, klass_without_ns, block_node = *node
-              klass = @klass_ns_mapping[klass_without_ns.to_sym]
+              _scope, _klass, block_node = *node
             end
 
             # This is not to raise error on dynamic assignments like `X = Y = Z = Class.new`.
@@ -42,9 +39,9 @@ module CodeKeeper
             next unless block_node.respond_to?(:class_definition?) && block_node.class_definition?
 
             # if the parent is an assignment_type or the parent of the parent is a masgn_type,
-            klass ||= @klass_ns_mapping[node.loc.name.source.to_sym]
+            #klass ||= @klass_ns_mapping[node.loc.name.source.to_sym]
 
-            @score_hash.store(klass, calculate(block_node))
+            @score_hash.store(build_namespace(block_node), calculate(block_node))
           end
         end
         @score_hash
@@ -97,33 +94,23 @@ module CodeKeeper
       end
  
       def build_namespace(node)
+        self_name = name_with_ns(node)
+
+        return self_name if node.each_ancestor(:class, :module).to_a.empty?
+
+        full_name = self_name.dup
+        node.each_ancestor(:class, :module) do |ancestor|
+          full_name = "#{name_with_ns(ancestor)}::#{full_name}"
+        end
+        full_name
+      end
+
+      def name_with_ns(node)
         ns = node.children.first&.namespace&.source
-        self_name = if ns.nil?
-                      node.children.first&.short_name.to_s
-                    else
-                      node.children.first.namespace.source + "::#{node.children.first.short_name}"
-                    end
-
-        return if @klass_ns_mapping.key? self_name.to_sym
-
-        # The first class name has no namespace.
-        @klass_ns_mapping.store(self_name.to_sym, self_name)
-        name_with_ns = self_name.dup
-
-        # To build namepace, const_node is enough. Class_node has more information than necesarry.
-        # TODO This considers only nested classes. A class may have multiple classes seperately.
-        node.each_descendant(:const) do |cnode|
-          next unless cnode.parent.class_type? || cnode.parent.module_type?
-          next if cnode.short_name.to_s == self_name
-
-          ns = cnode.namespace&.source
-          child_class_name = if ns.nil?
-                               cnode.short_name
-                             else
-                               "#{cnode.namespace.source}::#{cnode.short_name}"
-                             end
-          name_with_ns = "#{name_with_ns}::#{child_class_name}"
-          @klass_ns_mapping.store(child_class_name, name_with_ns)
+        if ns.nil?
+          node.children.first&.short_name.to_s
+        else
+          node.children.first.namespace.source + "::#{node.children.first.short_name}"
         end
       end
     end

--- a/spec/code_keeper/metrics/class_length_spec.rb
+++ b/spec/code_keeper/metrics/class_length_spec.rb
@@ -30,25 +30,30 @@ RSpec.describe CodeKeeper::Metrics::ClassLength do
 
     context 'A file has a class defined by overlapping constant assignments' do
       it 'returns a hash with a score of the class C' do
-        expected_hash = { C: 2 }
+        expected = {}
+        expected.store('C', 2)
         cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/overlapping_const_assignments.rb')
-        expect(cl.score).to eq(expected_hash)
+        expect(cl.score).to eq(expected)
       end
     end
 
     context 'A file has 2 classes defined by a singleton class' do
       it 'returns a hash with scores of 2 classes' do
-        expected_hash = { A: 3, B: 2 }
+        expected = {}
+        expected.store('A', 3)
+        expected.store('B', 2)
         cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/singleton.rb')
-        expect(cl.score).to eq(expected_hash)
+        expect(cl.score).to eq(expected)
       end
     end
 
     context 'A file has 2 classes defined by a Struct object, one of which is a multiple assignment' do
       it 'returns a hash with scores of 2 classes' do
-        expected_hash = { A: 2, B: 3 }
+        expected = {}
+        expected.store('A', 2)
+        expected.store('B', 3)
         cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/struct.rb')
-        expect(cl.score).to eq(expected_hash)
+        expect(cl.score).to eq(expected)
       end
     end
   end

--- a/spec/code_keeper/metrics/class_length_spec.rb
+++ b/spec/code_keeper/metrics/class_length_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe CodeKeeper::Metrics::ClassLength do
         expected.store('RootClass', 4)
         expected.store('RootClass::NameSpaceClass', 3)
         expected.store('RootClass::NameSpaceClass::A', 2)
+        expected.store('RootClass::SeperateClass', 1)
         expected.store('RootModule', 3)
         expected.store('RootModule::NameSpaceModule', 2)
         expected.store('RootModule::NameSpaceModule::B', 4)

--- a/spec/code_keeper/metrics/class_length_spec.rb
+++ b/spec/code_keeper/metrics/class_length_spec.rb
@@ -5,16 +5,25 @@ RSpec.describe CodeKeeper::Metrics::ClassLength do
     # This context also has a view of testing counting a comment just after class definition precisely.
     context 'A file has one class, in which there is a comment, an empty line' do
       it 'returns a hash with the value 1' do
+        expected = {}
+        expected.store('SimpleClass', 2)
         cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/simple_class.rb')
-        expect(cl.score).to eq({ SimpleClass: 2 })
+        expect(cl.score).to eq(expected)
       end
     end
 
     context 'A file has 3 classes, which are a namespace class and a inner class, and a class in a namespace module' do
       it 'returns a hash with scores of 3 classes' do
-        expected_hash = { NameSpaceClass: 4, A: 2, B: 3 }
+        expected = {}
+        expected.store('RootClass', 4)
+        expected.store('RootClass::NameSpaceClass', 3)
+        expected.store('RootClass::NameSpaceClass::A', 2)
+        expected.store('RootModule', 3)
+        expected.store('RootModule::NameSpaceModule', 2)
+        expected.store('RootModule::NameSpaceModule::B', 4)
+        expected.store('C::D::E', 2)
         cl = CodeKeeper::Metrics::ClassLength.new('spec/fixtures/class_samples/namespace.rb')
-        expect(cl.score).to eq(expected_hash)
+        expect(cl.score).to eq(expected)
       end
     end
 

--- a/spec/fixtures/class_samples/namespace.rb
+++ b/spec/fixtures/class_samples/namespace.rb
@@ -1,20 +1,44 @@
-class NameSpaceClass
-  class A
-    a = 1
-    a = 2
-  end
+class RootClass
+  class NameSpaceClass
+    class A
+    # A comment
+      a = 1
+      a = 2
+    end
 
-  # This is NameSpaceClass's field.
-  n = 1
-  n = 2
-  n = 3
-  n = 4
+    # NameSpaceClass comment
+    n = 1
+    n = 2
+    n = 3
+    n = 4
+  end
+  # RootClass comment
+  r = 1
+  r = 2
+  r = 3
 end
 
-module NameSpaceModule
-  class B
-    b = 1
-    b = 2
-    b = 3
+module RootModule 
+  module NameSpaceModule
+    # NameSpaceModule comment
+    n = 1
+    n = 2
+    module B
+      # B comment
+      b = 1
+      b = 2
+      b = 3
+      b = 4
+    end
   end
+  # RootModule comment
+  r = 1
+  r = 2
+  r = 3
+end
+
+class C::D::E
+  # comment
+  e = 1
+  e = 2
 end

--- a/spec/fixtures/class_samples/namespace.rb
+++ b/spec/fixtures/class_samples/namespace.rb
@@ -3,6 +3,7 @@ class RootClass
   class NameSpaceClass
     class A
     # A comment
+
       a = 1
       a = 2
     end
@@ -14,6 +15,13 @@ class RootClass
   end
   # RootClass comment
   r = 1
+
+  class SeperateClass
+    # Descirbes a class written seperately instead of inner class.
+
+    s = 1
+  end
+
   r = 2
   r = 3
 end

--- a/spec/fixtures/class_samples/namespace.rb
+++ b/spec/fixtures/class_samples/namespace.rb
@@ -1,4 +1,5 @@
 class RootClass
+  r = 4
   class NameSpaceClass
     class A
     # A comment
@@ -10,7 +11,6 @@ class RootClass
     n = 1
     n = 2
     n = 3
-    n = 4
   end
   # RootClass comment
   r = 1


### PR DESCRIPTION
Fix the bugs and make improvements as follows:

- The result doesn't show namespace.
- Doesn't count module length.
- RootClass length is wrong because there is a comment in inner nodes.
  - It's a bug of `#comment_line_count`.
- It's double counting if there are two inner nodes or more.
  - It's a bug of `#line_count_of_inner_nodes`.
  
 Namespaces are only supported like
```rb
module/class A
  class B; end
end

class C::D::E; end
```
, not using a singleton method nor using a struct.