### PR TITLE
Stop supporting Ruby 2.7 and 3.0 because of EOL.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [3.1, 3.2, 3.3]
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
As the tiltle says, the versions are EOL. I stop suporting them.

ref: https://www.ruby-lang.org/ja/downloads/branches/