### PR TITLE
test: add corpus golden report snapshots

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,15 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
+namespace :corpus do
+  desc "Regenerate committed golden reports for the vendored GitLab corpus"
+  task :regenerate_golden_reports do
+    require_relative "lib/code_keeper"
+    require_relative "spec/support/corpus_report_runner"
+    require_relative "spec/support/corpus_golden_report"
+
+    CorpusGoldenReport.regenerate_all
+  end
+end
+
 task default: %i[spec rubocop]

--- a/spec/code_keeper/golden_report_spec.rb
+++ b/spec/code_keeper/golden_report_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/corpus_report_runner"
+require "support/corpus_golden_report"
+
+RSpec.describe "GitLab corpus golden reports" do
+  it "has one snapshot per corpus file" do
+    expect(Dir[File.join(CorpusGoldenReport::ROOT, "**/*.json")].sort).to eq CorpusGoldenReport.snapshot_paths.sort
+  end
+
+  it "matches the current CodeKeeper report for every corpus file" do
+    CorpusReportRunner.file_paths.each do |path|
+      aggregate_failures path do
+        expect(File.read(CorpusGoldenReport.snapshot_path_for(path))).to eq CorpusGoldenReport.serialized_report_for(path)
+      end
+    end
+  end
+
+  it "stores repository-relative paths in snapshots" do
+    paths = CorpusGoldenReport.snapshot_paths.flat_map do |snapshot_path|
+      paths_in(JSON.parse(File.read(snapshot_path)))
+    end
+
+    expect(paths).to all(match(%r{\Aspec/fixtures/corpus/gitlab/}))
+  end
+
+  it "detects stale snapshots outside the corpus file list" do
+    stale_path = File.join(CorpusGoldenReport::ROOT, "obsolete.rb.json")
+    existing_paths = CorpusGoldenReport.snapshot_paths + [stale_path]
+
+    expect(CorpusGoldenReport.stale_snapshot_paths(existing_paths: existing_paths)).to eq [stale_path]
+  end
+
+  def paths_in(value)
+    case value
+    when Array
+      value.flat_map { |item| paths_in(item) }
+    when Hash
+      value.flat_map { |key, item| key == "path" ? [item] : paths_in(item) }
+    else
+      []
+    end
+  end
+end

--- a/spec/fixtures/corpus/gitlab/README.md
+++ b/spec/fixtures/corpus/gitlab/README.md
@@ -36,3 +36,18 @@ MIT Expat license notice included here.
 - `app/models/concerns/from_set_operator.rb`
 - `app/models/concerns/ci/partitionable.rb`
 - `spec/models/ability_spec.rb`
+
+## Golden Reports
+
+Committed golden reports live under `spec/fixtures/golden_reports/gitlab/`.
+There is one pretty-printed JSON report per corpus file, and report paths are
+recorded with repository-relative corpus paths.
+
+Regenerate them only as an explicit out-of-band maintenance task:
+
+```bash
+bundle exec rake corpus:regenerate_golden_reports
+```
+
+This regeneration task is not part of CI. Review the resulting JSON diff before
+committing it.

--- a/spec/fixtures/golden_reports/gitlab/app/graphql/types/project_type.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/graphql/types/project_type.rb.json
@@ -1,0 +1,872 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 40,
+        "max": 23.04,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#statistics_details_paths",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1163,
+            "end_line": 1174,
+            "value": 23.04
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#ci_pipeline_creation_inputs",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1068,
+            "end_line": 1094,
+            "value": 22.45
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#sast_ci_configuration",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1126,
+            "end_line": 1137,
+            "value": 14.14
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#pages_use_unique_domain",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 958,
+            "end_line": 968,
+            "value": 13.15
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#ci_config_variables",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1096,
+            "end_line": 1110,
+            "value": 12.88
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 40,
+        "max": 7,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#ci_config_variables",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1096,
+            "end_line": 1110,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#ci_pipeline_creation_inputs",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1068,
+            "end_line": 1094,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#ref_belongs_to_project?",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1112,
+            "end_line": 1119,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#pages_use_unique_domain",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 958,
+            "end_line": 968,
+            "value": 3
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Types::ProjectType#is_published",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 1056,
+            "end_line": 1058,
+            "value": 3
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 1004,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Types::ProjectType",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 4,
+            "end_line": 1252,
+            "value": 1004
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Types",
+            "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+            "start_line": 3,
+            "end_line": 1253,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType.authorization_scopes",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 15,
+      "end_line": 17,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ci_pipeline_creation_request",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 950,
+      "end_line": 952,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#pages_force_https",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 954,
+      "end_line": 956,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#pages_use_unique_domain",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 958,
+      "end_line": 968,
+      "value": 13.15
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#protectable_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 970,
+      "end_line": 972,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#timelog_categories",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 974,
+      "end_line": 976,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#label",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 978,
+      "end_line": 985,
+      "value": 10.82
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#container_protection_tag_rules",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 987,
+      "end_line": 990,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#jobs_enabled",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1022,
+      "end_line": 1024,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#open_issues_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1026,
+      "end_line": 1028,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#open_merge_requests_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1030,
+      "end_line": 1034,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#forks_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1036,
+      "end_line": 1038,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#is_catalog_resource",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1040,
+      "end_line": 1048,
+      "value": 9.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#explore_catalog_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1050,
+      "end_line": 1054,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#is_published",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1056,
+      "end_line": 1058,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#statistics",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1060,
+      "end_line": 1062,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#container_repositories_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1064,
+      "end_line": 1066,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ci_pipeline_creation_inputs",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1068,
+      "end_line": 1094,
+      "value": 22.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ci_config_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1096,
+      "end_line": 1110,
+      "value": 12.88
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ref_belongs_to_project?",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1112,
+      "end_line": 1119,
+      "value": 11.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#job",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1121,
+      "end_line": 1124,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#sast_ci_configuration",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1126,
+      "end_line": 1137,
+      "value": 14.14
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#service_desk_address",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1139,
+      "end_line": 1143,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#service_desk_enabled",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1145,
+      "end_line": 1147,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#languages",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1149,
+      "end_line": 1151,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#visible_forks",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1153,
+      "end_line": 1161,
+      "value": 11.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#statistics_details_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1163,
+      "end_line": 1174,
+      "value": 23.04
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#max_access_level",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1176,
+      "end_line": 1184,
+      "value": 10.95
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#organization_edit_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1186,
+      "end_line": 1194,
+      "value": 12.04
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#marked_for_deletion_on",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1198,
+      "end_line": 1200,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#permanent_deletion_date",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1202,
+      "end_line": 1204,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#web_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1206,
+      "end_line": 1208,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#edit_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1210,
+      "end_line": 1212,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#admin_show_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1214,
+      "end_line": 1218,
+      "value": 7.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#admin_edit_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1220,
+      "end_line": 1224,
+      "value": 7.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#grafana_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1226,
+      "end_line": 1228,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#only_allow_merge_if_pipeline_succeeds",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1230,
+      "end_line": 1232,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#allow_merge_on_skipped_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1234,
+      "end_line": 1236,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#project",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1240,
+      "end_line": 1242,
+      "value": 5.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#add_file_docs_link",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1244,
+      "end_line": 1251,
+      "value": 7.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType.authorization_scopes",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 15,
+      "end_line": 17,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ci_pipeline_creation_request",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 950,
+      "end_line": 952,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#pages_force_https",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 954,
+      "end_line": 956,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#pages_use_unique_domain",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 958,
+      "end_line": 968,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#protectable_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 970,
+      "end_line": 972,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#timelog_categories",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 974,
+      "end_line": 976,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#label",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 978,
+      "end_line": 985,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#container_protection_tag_rules",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 987,
+      "end_line": 990,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#jobs_enabled",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1022,
+      "end_line": 1024,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#open_issues_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1026,
+      "end_line": 1028,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#open_merge_requests_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1030,
+      "end_line": 1034,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#forks_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1036,
+      "end_line": 1038,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#is_catalog_resource",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1040,
+      "end_line": 1048,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#explore_catalog_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1050,
+      "end_line": 1054,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#is_published",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1056,
+      "end_line": 1058,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#statistics",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1060,
+      "end_line": 1062,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#container_repositories_count",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1064,
+      "end_line": 1066,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ci_pipeline_creation_inputs",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1068,
+      "end_line": 1094,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ci_config_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1096,
+      "end_line": 1110,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#ref_belongs_to_project?",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1112,
+      "end_line": 1119,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#job",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1121,
+      "end_line": 1124,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#sast_ci_configuration",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1126,
+      "end_line": 1137,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#service_desk_address",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1139,
+      "end_line": 1143,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#service_desk_enabled",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1145,
+      "end_line": 1147,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#languages",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1149,
+      "end_line": 1151,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#visible_forks",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1153,
+      "end_line": 1161,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#statistics_details_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1163,
+      "end_line": 1174,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#max_access_level",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1176,
+      "end_line": 1184,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#organization_edit_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1186,
+      "end_line": 1194,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#marked_for_deletion_on",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1198,
+      "end_line": 1200,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#permanent_deletion_date",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1202,
+      "end_line": 1204,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#web_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1206,
+      "end_line": 1208,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#edit_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1210,
+      "end_line": 1212,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#admin_show_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1214,
+      "end_line": 1218,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#admin_edit_path",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1220,
+      "end_line": 1224,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#grafana_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1226,
+      "end_line": 1228,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#only_allow_merge_if_pipeline_succeeds",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1230,
+      "end_line": 1232,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#allow_merge_on_skipped_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1234,
+      "end_line": 1236,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#project",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1240,
+      "end_line": 1242,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Types::ProjectType#add_file_docs_link",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 1244,
+      "end_line": 1251,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Types",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 3,
+      "end_line": 1253,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Types::ProjectType",
+      "path": "spec/fixtures/corpus/gitlab/app/graphql/types/project_type.rb",
+      "start_line": 4,
+      "end_line": 1252,
+      "value": 1004
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/ability.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/ability.rb.json
@@ -1,0 +1,476 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 18,
+        "max": 23.17,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ability.allowed?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 79,
+            "end_line": 111,
+            "value": 23.17
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ability.forget_all_but",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 164,
+            "end_line": 171,
+            "value": 9.43
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ability.forgetting",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 147,
+            "end_line": 156,
+            "value": 8.06
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ability.find_user_for_composite_identity_check",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 200,
+            "end_line": 207,
+            "value": 6.78
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ability.apply_filters_if_needed",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 179,
+            "end_line": 185,
+            "value": 4.69
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 18,
+        "max": 11,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ability.allowed?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 79,
+            "end_line": 111,
+            "value": 11
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ability.forget_all_but",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 164,
+            "end_line": 171,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ability.find_user_for_composite_identity_check",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 200,
+            "end_line": 207,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ability.apply_filters_if_needed",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 179,
+            "end_line": 185,
+            "value": 3
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ability.users_that_can_read_project",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 7,
+            "end_line": 11,
+            "value": 2
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 121,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Ability",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 3,
+            "end_line": 209,
+            "value": 121
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "singleton_class",
+            "scope_name": "class << Ability",
+            "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+            "start_line": 4,
+            "end_line": 208,
+            "value": 119
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_project",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 7,
+      "end_line": 11,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_group",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 15,
+      "end_line": 19,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_personal_snippet",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 23,
+      "end_line": 27,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_internal_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 30,
+      "end_line": 34,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_confidential_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 36,
+      "end_line": 40,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.issues_readable_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 48,
+      "end_line": 54,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.merge_requests_readable_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 63,
+      "end_line": 69,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.feature_flags_readable_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 71,
+      "end_line": 77,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 79,
+      "end_line": 111,
+      "value": 23.17
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.before_check",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 114,
+      "end_line": 116,
+      "value": 0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.policy_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 122,
+      "end_line": 126,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.forgetting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 147,
+      "end_line": 156,
+      "value": 8.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.ability_forgetting?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 160,
+      "end_line": 162,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.forget_all_but",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 164,
+      "end_line": 171,
+      "value": 9.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.forget_runner_result",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 173,
+      "end_line": 177,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.apply_filters_if_needed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 179,
+      "end_line": 185,
+      "value": 4.69
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.with_composite_identity_check",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 187,
+      "end_line": 198,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ability.find_user_for_composite_identity_check",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 200,
+      "end_line": 207,
+      "value": 6.78
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_project",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 7,
+      "end_line": 11,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_group",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 15,
+      "end_line": 19,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_personal_snippet",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 23,
+      "end_line": 27,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_internal_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 30,
+      "end_line": 34,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.users_that_can_read_confidential_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 36,
+      "end_line": 40,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.issues_readable_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 48,
+      "end_line": 54,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.merge_requests_readable_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 63,
+      "end_line": 69,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.feature_flags_readable_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 71,
+      "end_line": 77,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 79,
+      "end_line": 111,
+      "value": 11
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.before_check",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 114,
+      "end_line": 116,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.policy_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 122,
+      "end_line": 126,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.forgetting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 147,
+      "end_line": 156,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.ability_forgetting?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 160,
+      "end_line": 162,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.forget_all_but",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 164,
+      "end_line": 171,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.forget_runner_result",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 173,
+      "end_line": 177,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.apply_filters_if_needed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 179,
+      "end_line": 185,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.with_composite_identity_check",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 187,
+      "end_line": 198,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ability.find_user_for_composite_identity_check",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 200,
+      "end_line": 207,
+      "value": 4
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Ability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 3,
+      "end_line": 209,
+      "value": 121
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "singleton_class",
+      "scope_name": "class << Ability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/ability.rb",
+      "start_line": 4,
+      "end_line": 208,
+      "value": 119
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/concerns/ci/partitionable.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/concerns/ci/partitionable.rb.json
@@ -1,0 +1,314 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 9,
+        "max": 9.54,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#handle_partitionable_scope",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 75,
+            "end_line": 84,
+            "value": 9.54
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#partition_scope_value",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 76,
+            "end_line": 83,
+            "value": 8.6
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#handle_partitionable_ddl",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 86,
+            "end_line": 98,
+            "value": 7.35
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#handle_partitionable_through",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 65,
+            "end_line": 73,
+            "value": 7.28
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#set_partition_id",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 38,
+            "end_line": 43,
+            "value": 6.78
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 9,
+        "max": 4,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#set_partition_id",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 38,
+            "end_line": 43,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#handle_partitionable_scope",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 75,
+            "end_line": 84,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#partition_scope_value",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 76,
+            "end_line": 83,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable.registered_models",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 50,
+            "end_line": 54,
+            "value": 3
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::Partitionable#handle_partitionable_through",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 65,
+            "end_line": 73,
+            "value": 3
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 66,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Ci::Partitionable",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 18,
+            "end_line": 106,
+            "value": 66
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Ci",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+            "start_line": 3,
+            "end_line": 107,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#set_partition_id",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 38,
+      "end_line": 43,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#id_and_partition_pair",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 45,
+      "end_line": 47,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable.registered_models",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 50,
+      "end_line": 54,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#partitionable",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 57,
+      "end_line": 61,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#handle_partitionable_through",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 65,
+      "end_line": 73,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#handle_partitionable_scope",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 75,
+      "end_line": 84,
+      "value": 9.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#partition_scope_value",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 76,
+      "end_line": 83,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#handle_partitionable_ddl",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 86,
+      "end_line": 98,
+      "value": 7.35
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#create_database_partition?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 100,
+      "end_line": 104,
+      "value": 5.1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#set_partition_id",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 38,
+      "end_line": 43,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#id_and_partition_pair",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 45,
+      "end_line": 47,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable.registered_models",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 50,
+      "end_line": 54,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#partitionable",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 57,
+      "end_line": 61,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#handle_partitionable_through",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 65,
+      "end_line": 73,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#handle_partitionable_scope",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 75,
+      "end_line": 84,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#partition_scope_value",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 76,
+      "end_line": 83,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#handle_partitionable_ddl",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 86,
+      "end_line": 98,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::Partitionable#create_database_partition?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 100,
+      "end_line": 104,
+      "value": 2
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Ci",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 3,
+      "end_line": 107,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Ci::Partitionable",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ci/partitionable.rb",
+      "start_line": 18,
+      "end_line": 106,
+      "value": 66
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/concerns/from_set_operator.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/concerns/from_set_operator.rb.json
@@ -1,0 +1,116 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 2,
+        "max": 31.26,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "FromSetOperator#define_set_operator",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+            "start_line": 7,
+            "end_line": 46,
+            "value": 31.26
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "FromSetOperator#flatten_ar_array",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+            "start_line": 29,
+            "end_line": 43,
+            "value": 8.19
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 2,
+        "max": 6,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "FromSetOperator#define_set_operator",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+            "start_line": 7,
+            "end_line": 46,
+            "value": 6
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "FromSetOperator#flatten_ar_array",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+            "start_line": 29,
+            "end_line": 43,
+            "value": 3
+          }
+        ]
+      },
+      "class_length": {
+        "count": 1,
+        "max": 32,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "FromSetOperator",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+            "start_line": 3,
+            "end_line": 47,
+            "value": 32
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "FromSetOperator#define_set_operator",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+      "start_line": 7,
+      "end_line": 46,
+      "value": 31.26
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "FromSetOperator#flatten_ar_array",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+      "start_line": 29,
+      "end_line": 43,
+      "value": 8.19
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "FromSetOperator#define_set_operator",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+      "start_line": 7,
+      "end_line": 46,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "FromSetOperator#flatten_ar_array",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+      "start_line": 29,
+      "end_line": 43,
+      "value": 3
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "FromSetOperator",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/from_set_operator.rb",
+      "start_line": 3,
+      "end_line": 47,
+      "value": 32
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/concerns/has_repository.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/concerns/has_repository.rb.json
@@ -1,0 +1,656 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 29,
+        "max": 12.69,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "HasRepository#apply_desired_default_branch",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 99,
+            "end_line": 113,
+            "value": 12.69
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "HasRepository#default_branch_from_group_preferences",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 120,
+            "end_line": 125,
+            "value": 7.62
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "HasRepository#after_repository_change_head",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 158,
+            "end_line": 167,
+            "value": 7.07
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "HasRepository#after_create_repository",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 169,
+            "end_line": 178,
+            "value": 6.32
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "HasRepository#default_branch",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 81,
+            "end_line": 83,
+            "value": 5.48
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 29,
+        "max": 6,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "HasRepository#apply_desired_default_branch",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 99,
+            "end_line": 113,
+            "value": 6
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "HasRepository#default_branch=",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 85,
+            "end_line": 96,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "HasRepository#default_branch_from_group_preferences",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 120,
+            "end_line": 125,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "HasRepository#default_branch",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 81,
+            "end_line": 83,
+            "value": 3
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "HasRepository#valid_repo?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 19,
+            "end_line": 24,
+            "value": 2
+          }
+        ]
+      },
+      "class_length": {
+        "count": 1,
+        "max": 124,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "HasRepository",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+            "start_line": 10,
+            "end_line": 183,
+            "value": 124
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#valid_repo?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 19,
+      "end_line": 24,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repo_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 26,
+      "end_line": 30,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repository_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 33,
+      "end_line": 35,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#root_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 37,
+      "end_line": 39,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 41,
+      "end_line": 43,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#branch_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 45,
+      "end_line": 47,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#ref_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 49,
+      "end_line": 51,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#commit_by",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 53,
+      "end_line": 55,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#commits_by",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 57,
+      "end_line": 59,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 61,
+      "end_line": 63,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#storage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 65,
+      "end_line": 67,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#full_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 69,
+      "end_line": 71,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#lfs_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 73,
+      "end_line": 75,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#empty_repo?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 77,
+      "end_line": 79,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 81,
+      "end_line": 83,
+      "value": 5.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 85,
+      "end_line": 96,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#apply_desired_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 99,
+      "end_line": 113,
+      "value": 12.69
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch_from_preferences",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 116,
+      "end_line": 118,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch_from_group_preferences",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 120,
+      "end_line": 125,
+      "value": 7.62
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#reload_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 127,
+      "end_line": 131,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 133,
+      "end_line": 135,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#ssh_url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 137,
+      "end_line": 139,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#http_url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 141,
+      "end_line": 143,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#lfs_http_url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 146,
+      "end_line": 148,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#web_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 150,
+      "end_line": 152,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repository_size_checker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 154,
+      "end_line": 156,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#after_repository_change_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 158,
+      "end_line": 167,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#after_create_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 169,
+      "end_line": 178,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "HasRepository#after_change_head_branch_does_not_exist",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 180,
+      "end_line": 182,
+      "value": 0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#valid_repo?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 19,
+      "end_line": 24,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repo_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 26,
+      "end_line": 30,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repository_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 33,
+      "end_line": 35,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#root_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 37,
+      "end_line": 39,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 41,
+      "end_line": 43,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#branch_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 45,
+      "end_line": 47,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#ref_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 49,
+      "end_line": 51,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#commit_by",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 53,
+      "end_line": 55,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#commits_by",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 57,
+      "end_line": 59,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 61,
+      "end_line": 63,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#storage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 65,
+      "end_line": 67,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#full_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 69,
+      "end_line": 71,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#lfs_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 73,
+      "end_line": 75,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#empty_repo?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 77,
+      "end_line": 79,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 81,
+      "end_line": 83,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 85,
+      "end_line": 96,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#apply_desired_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 99,
+      "end_line": 113,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch_from_preferences",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 116,
+      "end_line": 118,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#default_branch_from_group_preferences",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 120,
+      "end_line": 125,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#reload_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 127,
+      "end_line": 131,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 133,
+      "end_line": 135,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#ssh_url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 137,
+      "end_line": 139,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#http_url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 141,
+      "end_line": 143,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#lfs_http_url_to_repo",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 146,
+      "end_line": 148,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#web_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 150,
+      "end_line": 152,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#repository_size_checker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 154,
+      "end_line": 156,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#after_repository_change_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 158,
+      "end_line": 167,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#after_create_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 169,
+      "end_line": 178,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "HasRepository#after_change_head_branch_does_not_exist",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 180,
+      "end_line": 182,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "HasRepository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/has_repository.rb",
+      "start_line": 10,
+      "end_line": 183,
+      "value": 124
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/concerns/ignorable_columns.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/concerns/ignorable_columns.rb.json
@@ -1,0 +1,170 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 3,
+        "max": 15.17,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "IgnorableColumns#ignore_columns",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 18,
+            "end_line": 30,
+            "value": 15.17
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "IgnorableColumns#ignored_columns_details",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 34,
+            "end_line": 40,
+            "value": 5.74
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "IgnorableColumns#safe_to_remove?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 7,
+            "end_line": 11,
+            "value": 3.61
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 3,
+        "max": 7,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "IgnorableColumns#ignore_columns",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 18,
+            "end_line": 30,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "IgnorableColumns#ignored_columns_details",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 34,
+            "end_line": 40,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "IgnorableColumns#safe_to_remove?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 7,
+            "end_line": 11,
+            "value": 2
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 28,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "IgnorableColumns",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 3,
+            "end_line": 44,
+            "value": 28
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "IgnorableColumns::ColumnIgnore",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+            "start_line": 6,
+            "end_line": 12,
+            "value": 4
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "IgnorableColumns#safe_to_remove?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 7,
+      "end_line": 11,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "IgnorableColumns#ignore_columns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 18,
+      "end_line": 30,
+      "value": 15.17
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "IgnorableColumns#ignored_columns_details",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 34,
+      "end_line": 40,
+      "value": 5.74
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "IgnorableColumns#safe_to_remove?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 7,
+      "end_line": 11,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "IgnorableColumns#ignore_columns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 18,
+      "end_line": 30,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "IgnorableColumns#ignored_columns_details",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 34,
+      "end_line": 40,
+      "value": 5
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "IgnorableColumns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 3,
+      "end_line": 44,
+      "value": 28
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "IgnorableColumns::ColumnIgnore",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/ignorable_columns.rb",
+      "start_line": 6,
+      "end_line": 12,
+      "value": 4
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/concerns/issuable.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/concerns/issuable.rb.json
@@ -1,0 +1,1448 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 73,
+        "max": 49.41,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Issuable#hook_association_changes",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 542,
+            "end_line": 572,
+            "value": 49.41
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Issuable#grouping_columns",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 438,
+            "end_line": 464,
+            "value": 28.91
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Issuable#order_labels_priority",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 390,
+            "end_line": 414,
+            "value": 25.02
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Issuable#gfm_autocomplete_search",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 276,
+            "end_line": 295,
+            "value": 20.25
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Issuable#sort_by_attribute",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 334,
+            "end_line": 364,
+            "value": 19.44
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 73,
+        "max": 16,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Issuable#hook_association_changes",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 542,
+            "end_line": 572,
+            "value": 16
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Issuable#sort_by_attribute",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 334,
+            "end_line": 364,
+            "value": 12
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Issuable#grouping_columns",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 438,
+            "end_line": 464,
+            "value": 6
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Issuable#notes_with_associations",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 662,
+            "end_line": 678,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Issuable#severity",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 222,
+            "end_line": 226,
+            "value": 4
+          }
+        ]
+      },
+      "class_length": {
+        "count": 1,
+        "max": 513,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Issuable",
+            "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+            "start_line": 9,
+            "end_line": 741,
+            "value": 513
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "self.labels_hash",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 155,
+      "end_line": 164,
+      "value": 13.19
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "self.locking_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 166,
+      "end_line": 168,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "self.max_number_of_assignees_or_reviewers_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 170,
+      "end_line": 173,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#issuable_type",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 176,
+      "end_line": 178,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#locking_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 182,
+      "end_line": 184,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#allows_multiple_assignees?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 186,
+      "end_line": 188,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#allows_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 190,
+      "end_line": 192,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_time_tracking?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 194,
+      "end_line": 196,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_severity?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 198,
+      "end_line": 200,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_escalation?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 202,
+      "end_line": 204,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#incident_type_issue?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 206,
+      "end_line": 208,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_assignee?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 210,
+      "end_line": 212,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_confidentiality?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 214,
+      "end_line": 216,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_lock_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 218,
+      "end_line": 220,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#severity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 222,
+      "end_line": 226,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#exportable_restricted_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 228,
+      "end_line": 230,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#importing_or_transitioning?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 232,
+      "end_line": 234,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#validate_description_length?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 238,
+      "end_line": 246,
+      "value": 7.68
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#truncate_description_on_import!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 248,
+      "end_line": 250,
+      "value": 5.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#validate_assignee_size_length",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 252,
+      "end_line": 257,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#participant_includes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 261,
+      "end_line": 263,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 272,
+      "end_line": 274,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#gfm_autocomplete_search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 276,
+      "end_line": 295,
+      "value": 20.25
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#available_states",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 297,
+      "end_line": 299,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#available_state_names",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 306,
+      "end_line": 308,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#full_search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 318,
+      "end_line": 328,
+      "value": 6.56
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#simple_sorts",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 330,
+      "end_line": 332,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#sort_by_attribute",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 334,
+      "end_line": 364,
+      "value": 19.44
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#order_due_date_and_labels_priority",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 366,
+      "end_line": 388,
+      "value": 14.18
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#order_labels_priority",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 390,
+      "end_line": 414,
+      "value": 25.02
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#with_label",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 416,
+      "end_line": 423,
+      "value": 10.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#any_label",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 425,
+      "end_line": 431,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#grouping_columns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 438,
+      "end_line": 464,
+      "value": 28.91
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#issue_grouping_columns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 471,
+      "end_line": 477,
+      "value": 7.68
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#to_ability_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 479,
+      "end_line": 481,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#parent_class",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 483,
+      "end_line": 485,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_association_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 487,
+      "end_line": 489,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#state",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 492,
+      "end_line": 494,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#state=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 496,
+      "end_line": 498,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#resource_parent",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 500,
+      "end_line": 502,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_or_author?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 504,
+      "end_line": 506,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 508,
+      "end_line": 515,
+      "value": 8.25
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#open?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 517,
+      "end_line": 519,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#overdue?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 521,
+      "end_line": 525,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#user_notes_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 527,
+      "end_line": 535,
+      "value": 10.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#subscribed_without_subscriptions?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 537,
+      "end_line": 539,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#hook_association_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 542,
+      "end_line": 572,
+      "value": 49.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#reviewers_hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 575,
+      "end_line": 583,
+      "value": 13.93
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#hook_reviewer_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 585,
+      "end_line": 595,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#to_hook_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 597,
+      "end_line": 610,
+      "value": 9.27
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#labels_array",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 612,
+      "end_line": 614,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#label_names",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 616,
+      "end_line": 618,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#labels_hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 620,
+      "end_line": 622,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#allows_scoped_labels?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 624,
+      "end_line": 626,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#to_ability_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 634,
+      "end_line": 636,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#card_attributes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 639,
+      "end_line": 644,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_list",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 646,
+      "end_line": 648,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_username_list",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 650,
+      "end_line": 652,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#system_note_authors",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 654,
+      "end_line": 656,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#notes_for_participants",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 658,
+      "end_line": 660,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#notes_with_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 662,
+      "end_line": 678,
+      "value": 8.66
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#updated_tasks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 680,
+      "end_line": 685,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#can_move?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 692,
+      "end_line": 694,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#first_contribution?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 699,
+      "end_line": 701,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#draftless_title_changed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 706,
+      "end_line": 708,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_health_status?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 710,
+      "end_line": 712,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_assignees",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 714,
+      "end_line": 716,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_labels",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 718,
+      "end_line": 720,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_severity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 722,
+      "end_line": 724,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_target_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 726,
+      "end_line": 728,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_escalation_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 730,
+      "end_line": 732,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_total_time_spent",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 734,
+      "end_line": 736,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_time_change",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 738,
+      "end_line": 740,
+      "value": 3.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "self.labels_hash",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 155,
+      "end_line": 164,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "self.locking_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 166,
+      "end_line": 168,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "self.max_number_of_assignees_or_reviewers_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 170,
+      "end_line": 173,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#issuable_type",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 176,
+      "end_line": 178,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#locking_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 182,
+      "end_line": 184,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#allows_multiple_assignees?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 186,
+      "end_line": 188,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#allows_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 190,
+      "end_line": 192,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_time_tracking?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 194,
+      "end_line": 196,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_severity?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 198,
+      "end_line": 200,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_escalation?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 202,
+      "end_line": 204,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#incident_type_issue?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 206,
+      "end_line": 208,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_assignee?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 210,
+      "end_line": 212,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_confidentiality?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 214,
+      "end_line": 216,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_lock_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 218,
+      "end_line": 220,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#severity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 222,
+      "end_line": 226,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#exportable_restricted_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 228,
+      "end_line": 230,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#importing_or_transitioning?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 232,
+      "end_line": 234,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#validate_description_length?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 238,
+      "end_line": 246,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#truncate_description_on_import!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 248,
+      "end_line": 250,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#validate_assignee_size_length",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 252,
+      "end_line": 257,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#participant_includes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 261,
+      "end_line": 263,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 272,
+      "end_line": 274,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#gfm_autocomplete_search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 276,
+      "end_line": 295,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#available_states",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 297,
+      "end_line": 299,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#available_state_names",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 306,
+      "end_line": 308,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#full_search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 318,
+      "end_line": 328,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#simple_sorts",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 330,
+      "end_line": 332,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#sort_by_attribute",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 334,
+      "end_line": 364,
+      "value": 12
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#order_due_date_and_labels_priority",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 366,
+      "end_line": 388,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#order_labels_priority",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 390,
+      "end_line": 414,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#with_label",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 416,
+      "end_line": 423,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#any_label",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 425,
+      "end_line": 431,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#grouping_columns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 438,
+      "end_line": 464,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#issue_grouping_columns",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 471,
+      "end_line": 477,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#to_ability_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 479,
+      "end_line": 481,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#parent_class",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 483,
+      "end_line": 485,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_association_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 487,
+      "end_line": 489,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#state",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 492,
+      "end_line": 494,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#state=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 496,
+      "end_line": 498,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#resource_parent",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 500,
+      "end_line": 502,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_or_author?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 504,
+      "end_line": 506,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 508,
+      "end_line": 515,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#open?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 517,
+      "end_line": 519,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#overdue?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 521,
+      "end_line": 525,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#user_notes_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 527,
+      "end_line": 535,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#subscribed_without_subscriptions?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 537,
+      "end_line": 539,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#hook_association_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 542,
+      "end_line": 572,
+      "value": 16
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#reviewers_hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 575,
+      "end_line": 583,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#hook_reviewer_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 585,
+      "end_line": 595,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#to_hook_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 597,
+      "end_line": 610,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#labels_array",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 612,
+      "end_line": 614,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#label_names",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 616,
+      "end_line": 618,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#labels_hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 620,
+      "end_line": 622,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#allows_scoped_labels?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 624,
+      "end_line": 626,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#to_ability_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 634,
+      "end_line": 636,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#card_attributes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 639,
+      "end_line": 644,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_list",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 646,
+      "end_line": 648,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#assignee_username_list",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 650,
+      "end_line": 652,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#system_note_authors",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 654,
+      "end_line": 656,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#notes_for_participants",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 658,
+      "end_line": 660,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#notes_with_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 662,
+      "end_line": 678,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#updated_tasks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 680,
+      "end_line": 685,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#can_move?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 692,
+      "end_line": 694,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#first_contribution?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 699,
+      "end_line": 701,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#draftless_title_changed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 706,
+      "end_line": 708,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#supports_health_status?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 710,
+      "end_line": 712,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_assignees",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 714,
+      "end_line": 716,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_labels",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 718,
+      "end_line": 720,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_severity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 722,
+      "end_line": 724,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_target_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 726,
+      "end_line": 728,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_escalation_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 730,
+      "end_line": 732,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_total_time_spent",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 734,
+      "end_line": 736,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Issuable#old_time_change",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 738,
+      "end_line": 740,
+      "value": 2
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Issuable",
+      "path": "spec/fixtures/corpus/gitlab/app/models/concerns/issuable.rb",
+      "start_line": 9,
+      "end_line": 741,
+      "value": 513
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/merge_request.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/merge_request.rb.json
@@ -1,0 +1,5768 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 312,
+        "max": 55.16,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#predefined_variables",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 2225,
+            "end_line": 2247,
+            "value": 55.16
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#committer_emails_via_metadata_query",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 3037,
+            "end_line": 3054,
+            "value": 32.4
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#update_diff_discussion_positions",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 2489,
+            "end_line": 2525,
+            "value": 27.73
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#default_merge_commit_message",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 1970,
+            "end_line": 1992,
+            "value": 25.18
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#closes_issues",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 1880,
+            "end_line": 1892,
+            "value": 25.02
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 312,
+        "max": 12,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#update_diff_discussion_positions",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 2489,
+            "end_line": 2525,
+            "value": 12
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#merged_at",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 2469,
+            "end_line": 2478,
+            "value": 9
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#validate_branches",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 1361,
+            "end_line": 1381,
+            "value": 8
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#default_merge_commit_message",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 1970,
+            "end_line": 1992,
+            "value": 8
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequest#validate_branch_existence",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 1400,
+            "end_line": 1410,
+            "value": 7
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 2370,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "MergeRequest",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 3,
+            "end_line": 3302,
+            "value": 2370
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "singleton_class",
+            "scope_name": "class << MergeRequest",
+            "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+            "start_line": 934,
+            "end_line": 938,
+            "value": 3
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#suggested_reviewer_users",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 87,
+      "end_line": 89,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_request_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 101,
+      "end_line": 105,
+      "value": 5.92
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.available_state_names",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 201,
+      "end_line": 203,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#check_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 321,
+      "end_line": 323,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.batch_mark_as_unchecked",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 337,
+      "end_line": 353,
+      "value": 11.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.batch_mark_as_checking",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 359,
+      "end_line": 371,
+      "value": 8.31
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.batch_clear_merge_error",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 373,
+      "end_line": 381,
+      "value": 6.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#public_merge_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 385,
+      "end_line": 387,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.total_time_to_merge",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 732,
+      "end_line": 741,
+      "value": 9.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reference_prefix",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 760,
+      "end_line": 762,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.order_by_metric_column",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 764,
+      "end_line": 785,
+      "value": 13.3
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.recent_target_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 795,
+      "end_line": 801,
+      "value": 9.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.recent_source_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 803,
+      "end_line": 809,
+      "value": 9.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.distinct_source_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 811,
+      "end_line": 813,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.sort_by_attribute",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 815,
+      "end_line": 824,
+      "value": 6.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reviewers_subquery",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 826,
+      "end_line": 830,
+      "value": 6.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#rebase_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 832,
+      "end_line": 834,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#permits_force_push?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 836,
+      "end_line": 840,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 845,
+      "end_line": 847,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 849,
+      "end_line": 853,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_pipeline_success?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 855,
+      "end_line": 857,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 862,
+      "end_line": 867,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.link_reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 869,
+      "end_line": 871,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reference_valid?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 873,
+      "end_line": 875,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.project_foreign_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 877,
+      "end_line": 879,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.in_projects",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 891,
+      "end_line": 898,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.set_latest_merge_request_diff_ids!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 906,
+      "end_line": 918,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.draft?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 922,
+      "end_line": 924,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.draftless_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 926,
+      "end_line": 928,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.draft_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 930,
+      "end_line": 932,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.participant_includes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 940,
+      "end_line": 942,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 944,
+      "end_line": 950,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#preload_commits_metadata",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 952,
+      "end_line": 961,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 963,
+      "end_line": 973,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_ids_to_filter_from_approvers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 975,
+      "end_line": 981,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committers_to_filter_from_approvers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 984,
+      "end_line": 990,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draftless_title_changed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 995,
+      "end_line": 997,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1000,
+      "end_line": 1002,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#to_reference",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1005,
+      "end_line": 1009,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#context_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1011,
+      "end_line": 1013,
+      "value": 4.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_context_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1015,
+      "end_line": 1017,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#context_commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1019,
+      "end_line": 1021,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1023,
+      "end_line": 1034,
+      "value": 11.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1036,
+      "end_line": 1044,
+      "value": 7.62
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1046,
+      "end_line": 1059,
+      "value": 13.56
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#supports_suggestion?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1061,
+      "end_line": 1063,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#supports_lock_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1065,
+      "end_line": 1069,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_async",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1074,
+      "end_line": 1081,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#rebase_async",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1085,
+      "end_line": 1103,
+      "value": 11.22
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_participants",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1105,
+      "end_line": 1113,
+      "value": 8.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1115,
+      "end_line": 1117,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#raw_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1119,
+      "end_line": 1121,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_for_streaming",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1123,
+      "end_line": 1132,
+      "value": 8.31
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_for_streaming_by_changed_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1134,
+      "end_line": 1137,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1139,
+      "end_line": 1148,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#non_latest_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1150,
+      "end_line": 1152,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#note_positions_for_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1154,
+      "end_line": 1169,
+      "value": 14.7
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#preloads_discussion_diff_highlighting?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1171,
+      "end_line": 1173,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#discussions_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1175,
+      "end_line": 1184,
+      "value": 9.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_stats",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1186,
+      "end_line": 1192,
+      "value": 9.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_size",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1194,
+      "end_line": 1198,
+      "value": 7.21
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#modified_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1200,
+      "end_line": 1208,
+      "value": 9.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#changed_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1210,
+      "end_line": 1212,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#new_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1215,
+      "end_line": 1217,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1219,
+      "end_line": 1225,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_start_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1227,
+      "end_line": 1233,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_base_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1235,
+      "end_line": 1241,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1243,
+      "end_line": 1249,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merged_in_repository?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1251,
+      "end_line": 1253,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_commit_reachable_from_target_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1255,
+      "end_line": 1272,
+      "value": 18.55
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_ref",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1280,
+      "end_line": 1285,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_ref",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1287,
+      "end_line": 1292,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1294,
+      "end_line": 1300,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1302,
+      "end_line": 1306,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#branch_merge_base_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1308,
+      "end_line": 1315,
+      "value": 4.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1317,
+      "end_line": 1319,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1321,
+      "end_line": 1323,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1325,
+      "end_line": 1331,
+      "value": 5.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#repository_diff_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1337,
+      "end_line": 1343,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#branch_merge_base_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1345,
+      "end_line": 1347,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#existing_mrs_targeting_same_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1349,
+      "end_line": 1359,
+      "value": 11.22
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1361,
+      "end_line": 1381,
+      "value": 18.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#conflicting_mr_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1383,
+      "end_line": 1388,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_branch_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1390,
+      "end_line": 1398,
+      "value": 5.92
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_branch_existence",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1400,
+      "end_line": 1410,
+      "value": 17.09
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_target_project",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1412,
+      "end_line": 1416,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_fork",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1418,
+      "end_line": 1424,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_reviewer_size_length",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1426,
+      "end_line": 1431,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_ongoing?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1433,
+      "end_line": 1439,
+      "value": 8.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#closed_or_merged_without_fork?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1441,
+      "end_line": 1443,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_missing?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1445,
+      "end_line": 1450,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ensure_merge_request_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1452,
+      "end_line": 1456,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#create_merge_request_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1458,
+      "end_line": 1473,
+      "value": 9.27
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_request_diff_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1475,
+      "end_line": 1490,
+      "value": 10.05
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#previous_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1492,
+      "end_line": 1494,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#version_params_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1496,
+      "end_line": 1505,
+      "value": 6.63
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#clear_memoized_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1507,
+      "end_line": 1513,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reload_diff_if_branch_changed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1515,
+      "end_line": 1520,
+      "value": 6.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reload_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1523,
+      "end_line": 1528,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#check_mergeability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1530,
+      "end_line": 1540,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffable_merge_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1543,
+      "end_line": 1545,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recheck_merge_status?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1549,
+      "end_line": 1551,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_event",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1553,
+      "end_line": 1555,
+      "value": 5.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#closed_event",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1557,
+      "end_line": 1559,
+      "value": 5.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draft?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1561,
+      "end_line": 1563,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draftless_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1566,
+      "end_line": 1568,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draft_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1571,
+      "end_line": 1573,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#skipped_auto_merge_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1576,
+      "end_line": 1601,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#auto_merge_eligible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1607,
+      "end_line": 1613,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1627,
+      "end_line": 1634,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.mergeable_state_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1636,
+      "end_line": 1638,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.mergeable_state_checks_by_tier",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1650,
+      "end_line": 1666,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.mergeable_git_state_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1668,
+      "end_line": 1673,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.all_mergeability_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1675,
+      "end_line": 1677,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1688,
+      "end_line": 1695,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable_git_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1698,
+      "end_line": 1705,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeability_checks_pass?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1708,
+      "end_line": 1714,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_mergeability_checks_results",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1716,
+      "end_line": 1721,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ff_merge_possible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1723,
+      "end_line": 1725,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#should_be_rebased?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1727,
+      "end_line": 1729,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_cancel_auto_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1731,
+      "end_line": 1733,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1735,
+      "end_line": 1741,
+      "value": 14.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#should_remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1743,
+      "end_line": 1745,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#force_remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1747,
+      "end_line": 1749,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#auto_merge_strategy",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1751,
+      "end_line": 1755,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#default_auto_merge_strategy",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1757,
+      "end_line": 1759,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#auto_merge_strategy=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1761,
+      "end_line": 1763,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1765,
+      "end_line": 1767,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#notify_conflict?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1769,
+      "end_line": 1778,
+      "value": 12.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#related_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1780,
+      "end_line": 1788,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1792,
+      "end_line": 1800,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#duo_code_review_progress_note",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1802,
+      "end_line": 1804,
+      "value": 0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable_discussions_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1806,
+      "end_line": 1810,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#for_fork?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1812,
+      "end_line": 1814,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#for_same_project?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1816,
+      "end_line": 1818,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#cache_closing_issues_after_merge!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1820,
+      "end_line": 1837,
+      "value": 21.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#cache_merge_request_closes_issues!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1844,
+      "end_line": 1858,
+      "value": 15.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#visible_closing_issues_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1860,
+      "end_line": 1877,
+      "value": 16.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#closes_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1880,
+      "end_line": 1892,
+      "value": 25.02
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#issues_mentioned_but_not_closing",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1894,
+      "end_line": 1901,
+      "value": 11.22
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#related_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1903,
+      "end_line": 1913,
+      "value": 17.97
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_project_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1915,
+      "end_line": 1921,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1923,
+      "end_line": 1929,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1931,
+      "end_line": 1937,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_project_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1939,
+      "end_line": 1945,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#preload_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1947,
+      "end_line": 1956,
+      "value": 10.2
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1958,
+      "end_line": 1962,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1964,
+      "end_line": 1968,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#default_merge_commit_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1970,
+      "end_line": 1992,
+      "value": 25.18
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#default_squash_commit_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1994,
+      "end_line": 1998,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_multiline_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2001,
+      "end_line": 2005,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_multiline_commit_description",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2008,
+      "end_line": 2013,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2015,
+      "end_line": 2020,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_ci?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2022,
+      "end_line": 2026,
+      "value": 8.94
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#branch_missing?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2028,
+      "end_line": 2030,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#broken?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2032,
+      "end_line": 2034,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_be_merged_by?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2036,
+      "end_line": 2039,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#only_allow_merge_if_pipeline_succeeds?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2041,
+      "end_line": 2043,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allow_merge_without_pipeline?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2045,
+      "end_line": 2047,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#only_allow_merge_if_all_discussions_are_resolved?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2049,
+      "end_line": 2051,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_ci_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2054,
+      "end_line": 2056,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#pipeline_creating?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2058,
+      "end_line": 2060,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#environments_in_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2062,
+      "end_line": 2064,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#fetch_ref!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2066,
+      "end_line": 2069,
+      "value": 8.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_ref_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2073,
+      "end_line": 2077,
+      "value": 9.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ref_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2079,
+      "end_line": 2081,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_ref_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2083,
+      "end_line": 2085,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#train_ref_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2087,
+      "end_line": 2089,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#rebase_on_merge_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2091,
+      "end_line": 2093,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#schedule_cleanup_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2095,
+      "end_line": 2103,
+      "value": 9.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#refs_to_cleanup",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2105,
+      "end_line": 2112,
+      "value": 12.69
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#cleanup_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2114,
+      "end_line": 2116,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#async_cleanup_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2118,
+      "end_line": 2120,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.merge_request_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2122,
+      "end_line": 2124,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.merge_train_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2126,
+      "end_line": 2128,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#in_locked_state",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2130,
+      "end_line": 2144,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#force_unlock_and_close",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2160,
+      "end_line": 2164,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_and_mark_in_progress_merge_commit_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2166,
+      "end_line": 2172,
+      "value": 6.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diverged_commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2174,
+      "end_line": 2187,
+      "value": 15.94
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compute_diverged_commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2189,
+      "end_line": 2194,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diverged_from_target_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2197,
+      "end_line": 2199,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2201,
+      "end_line": 2205,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2207,
+      "end_line": 2218,
+      "value": 7.35
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_test_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2220,
+      "end_line": 2222,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#predefined_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2225,
+      "end_line": 2247,
+      "value": 55.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_test_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2250,
+      "end_line": 2256,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_accessibility_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2258,
+      "end_line": 2260,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_coverage_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2262,
+      "end_line": 2264,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_coverage_reports_for?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2266,
+      "end_line": 2268,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_terraform_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2270,
+      "end_line": 2272,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_accessibility_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2274,
+      "end_line": 2280,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_coverage_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2286,
+      "end_line": 2292,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_codequality_mr_diff_report?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2294,
+      "end_line": 2296,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_codequality_mr_diff_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2302,
+      "end_line": 2308,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_codequality_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2310,
+      "end_line": 2312,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_codequality_reports_for?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2314,
+      "end_line": 2316,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_codequality_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2318,
+      "end_line": 2326,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_terraform_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2328,
+      "end_line": 2334,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_exposed_artifacts?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2336,
+      "end_line": 2338,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_exposed_artifacts",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2344,
+      "end_line": 2350,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2355,
+      "end_line": 2364,
+      "value": 10.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_sast_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2366,
+      "end_line": 2369,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#calculate_reactive_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2371,
+      "end_line": 2380,
+      "value": 9.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_diff_head_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2384,
+      "end_line": 2389,
+      "value": 11.18
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2391,
+      "end_line": 2399,
+      "value": 7.35
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_commit_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2403,
+      "end_line": 2407,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2410,
+      "end_line": 2412,
+      "value": 4.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2414,
+      "end_line": 2416,
+      "value": 4.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merged_commit_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2418,
+      "end_line": 2423,
+      "value": 6.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#short_merged_commit_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2425,
+      "end_line": 2429,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_to_revert",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2432,
+      "end_line": 2446,
+      "value": 10.3
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_to_cherry_pick",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2448,
+      "end_line": 2450,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_be_reverted?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2452,
+      "end_line": 2467,
+      "value": 9.7
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merged_at",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2469,
+      "end_line": 2478,
+      "value": 16.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_be_cherry_picked?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2480,
+      "end_line": 2482,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_complete_diff_refs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2484,
+      "end_line": 2486,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_diff_discussion_positions",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2489,
+      "end_line": 2525,
+      "value": 27.73
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#keep_around_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2528,
+      "end_line": 2532,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#enqueue_keep_around_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2534,
+      "end_line": 2543,
+      "value": 9.22
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#async_keep_around_refs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2545,
+      "end_line": 2549,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_commits?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2551,
+      "end_line": 2553,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_no_commits?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2555,
+      "end_line": 2557,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#pipeline_coverage_delta",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2559,
+      "end_line": 2563,
+      "value": 9.85
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#comparison_base_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2565,
+      "end_line": 2577,
+      "value": 10.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_base_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2579,
+      "end_line": 2585,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#base_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2588,
+      "end_line": 2590,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#discussions_rendered_on_frontend?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2593,
+      "end_line": 2595,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#invalidate_project_counter_caches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2598,
+      "end_line": 2600,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_contribution?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2603,
+      "end_line": 2607,
+      "value": 11.18
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allow_collaboration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2613,
+      "end_line": 2615,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#collaborative_push_possible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2619,
+      "end_line": 2624,
+      "value": 12.53
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_allow_collaboration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2626,
+      "end_line": 2629,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_diff_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2631,
+      "end_line": 2633,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#real_time_notes_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2635,
+      "end_line": 2637,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_visible_deployments",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2639,
+      "end_line": 2641,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#banzai_render_context",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2643,
+      "end_line": 2645,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ensure_metrics!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2647,
+      "end_line": 2649,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allows_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2651,
+      "end_line": 2653,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allows_multiple_assignees?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2655,
+      "end_line": 2657,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allows_multiple_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2659,
+      "end_line": 2661,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reviewer_auto_assignment_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2663,
+      "end_line": 2665,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#supports_assignee?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2667,
+      "end_line": 2669,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_reviewer",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2671,
+      "end_line": 2673,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_request_reviewers_with",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2675,
+      "end_line": 2677,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#create_requested_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2679,
+      "end_line": 2681,
+      "value": 0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#destroy_requested_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2683,
+      "end_line": 2685,
+      "value": 0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#batch_update_reviewer_state",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2687,
+      "end_line": 2689,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#enabled_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2691,
+      "end_line": 2696,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#includes_ci_config?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2698,
+      "end_line": 2702,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#context_commits_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2704,
+      "end_line": 2708,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_default_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2710,
+      "end_line": 2712,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_blocked_by_other_mrs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2714,
+      "end_line": 2716,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#execute_merge_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2718,
+      "end_line": 2724,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_suggest_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2726,
+      "end_line": 2728,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#hidden?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2730,
+      "end_line": 2732,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_batch_cache_with_max_age?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2734,
+      "end_line": 2736,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#prepared?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2738,
+      "end_line": 2740,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#initial_preparation?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2742,
+      "end_line": 2744,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#check_for_spam?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2746,
+      "end_line": 2748,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#missing_required_squash?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2750,
+      "end_line": 2752,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#current_patch_id_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2754,
+      "end_line": 2756,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_pipeline_considered_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2758,
+      "end_line": 2774,
+      "value": 8.66
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#temporarily_unapproved?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2776,
+      "end_line": 2778,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_jira_issue_keys?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2780,
+      "end_line": 2788,
+      "value": 9.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_exclusive_lease",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2790,
+      "end_line": 2794,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_and_target_branches_exist?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2796,
+      "end_line": 2798,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_diffs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2800,
+      "end_line": 2806,
+      "value": 8.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#add_to_locked_set",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2808,
+      "end_line": 2810,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#remove_from_locked_set",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2812,
+      "end_line": 2814,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_diffs_slice",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2816,
+      "end_line": 2825,
+      "value": 8.31
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_option",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2827,
+      "end_line": 2829,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#log_approval_deletion_on_merged_or_locked_mr",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2833,
+      "end_line": 2847,
+      "value": 10.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reached_versions_limit?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2849,
+      "end_line": 2851,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reached_diff_commits_limit?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2853,
+      "end_line": 2860,
+      "value": 6.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_batch_cache_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2862,
+      "end_line": 2867,
+      "value": 7.21
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2869,
+      "end_line": 2890,
+      "value": 14.46
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#append_merge_params",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2917,
+      "end_line": 2922,
+      "value": 8.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#clear_merge_params",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2924,
+      "end_line": 2929,
+      "value": 8.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_merge_ref_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2931,
+      "end_line": 2943,
+      "value": 10.2
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_merge_jid",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2945,
+      "end_line": 2957,
+      "value": 10.2
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ensure_merge_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2959,
+      "end_line": 2969,
+      "value": 9.11
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#viewable_recent_merge_request_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2971,
+      "end_line": 2976,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#show_context_commits_diff?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2978,
+      "end_line": 2980,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_allow_broken",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2988,
+      "end_line": 2994,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#state_changed_since_load?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3002,
+      "end_line": 3008,
+      "value": 9.11
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#publish_code_conflict_event",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3010,
+      "end_line": 3013,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_emails_from_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3015,
+      "end_line": 3034,
+      "value": 13.64
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_emails_via_metadata_query",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3037,
+      "end_line": 3054,
+      "value": 32.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_emails_via_direct_query",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3056,
+      "end_line": 3065,
+      "value": 20.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_cached_closing_issues_from_description!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3067,
+      "end_line": 3080,
+      "value": 7.14
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#bulk_insert_cached_closing_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3082,
+      "end_line": 3099,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_data_attributes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3101,
+      "end_line": 3117,
+      "value": 13.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_merge_data_sync",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3119,
+      "end_line": 3140,
+      "value": 7.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_single_transaction_merge_data_sync",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3142,
+      "end_line": 3156,
+      "value": 6.63
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#save_merge_data_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3158,
+      "end_line": 3169,
+      "value": 13.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#dual_write_to_merge_data_ff_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3171,
+      "end_line": 3173,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#viewable_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3176,
+      "end_line": 3180,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_pipelines_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3182,
+      "end_line": 3185,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#set_draft_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3187,
+      "end_line": 3189,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#expire_ancestor_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3191,
+      "end_line": 3193,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#missing_report_error",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3195,
+      "end_line": 3197,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_rebase_lock",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3199,
+      "end_line": 3201,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_retried_nowait_lock",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3207,
+      "end_line": 3217,
+      "value": 6.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3219,
+      "end_line": 3229,
+      "value": 21.05
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#expire_etag_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3231,
+      "end_line": 3236,
+      "value": 7.14
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#report_type_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3238,
+      "end_line": 3248,
+      "value": 11.22
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#truncate_mr_description",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3250,
+      "end_line": 3256,
+      "value": 7.21
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#pipeline_has_report_in_self_or_descendants?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3258,
+      "end_line": 3262,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_commit_shas_from_metadata",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3264,
+      "end_line": 3281,
+      "value": 14.35
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#resolve_diff_version",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3283,
+      "end_line": 3291,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#read_new_commits_table?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3293,
+      "end_line": 3295,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#project_id_pruning_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3298,
+      "end_line": 3300,
+      "value": 2.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#suggested_reviewer_users",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 87,
+      "end_line": 89,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_request_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 101,
+      "end_line": 105,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.available_state_names",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 201,
+      "end_line": 203,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#check_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 321,
+      "end_line": 323,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.batch_mark_as_unchecked",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 337,
+      "end_line": 353,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.batch_mark_as_checking",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 359,
+      "end_line": 371,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.batch_clear_merge_error",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 373,
+      "end_line": 381,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#public_merge_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 385,
+      "end_line": 387,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.total_time_to_merge",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 732,
+      "end_line": 741,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reference_prefix",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 760,
+      "end_line": 762,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.order_by_metric_column",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 764,
+      "end_line": 785,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.recent_target_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 795,
+      "end_line": 801,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.recent_source_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 803,
+      "end_line": 809,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.distinct_source_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 811,
+      "end_line": 813,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.sort_by_attribute",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 815,
+      "end_line": 824,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reviewers_subquery",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 826,
+      "end_line": 830,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#rebase_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 832,
+      "end_line": 834,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#permits_force_push?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 836,
+      "end_line": 840,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 845,
+      "end_line": 847,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 849,
+      "end_line": 853,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_pipeline_success?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 855,
+      "end_line": 857,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 862,
+      "end_line": 867,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.link_reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 869,
+      "end_line": 871,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.reference_valid?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 873,
+      "end_line": 875,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.project_foreign_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 877,
+      "end_line": 879,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.in_projects",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 891,
+      "end_line": 898,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.set_latest_merge_request_diff_ids!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 906,
+      "end_line": 918,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.draft?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 922,
+      "end_line": 924,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.draftless_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 926,
+      "end_line": 928,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.draft_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 930,
+      "end_line": 932,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.participant_includes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 940,
+      "end_line": 942,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 944,
+      "end_line": 950,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#preload_commits_metadata",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 952,
+      "end_line": 961,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 963,
+      "end_line": 973,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_ids_to_filter_from_approvers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 975,
+      "end_line": 981,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committers_to_filter_from_approvers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 984,
+      "end_line": 990,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draftless_title_changed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 995,
+      "end_line": 997,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1000,
+      "end_line": 1002,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#to_reference",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1005,
+      "end_line": 1009,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#context_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1011,
+      "end_line": 1013,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_context_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1015,
+      "end_line": 1017,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#context_commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1019,
+      "end_line": 1021,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1023,
+      "end_line": 1034,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1036,
+      "end_line": 1044,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1046,
+      "end_line": 1059,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#supports_suggestion?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1061,
+      "end_line": 1063,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#supports_lock_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1065,
+      "end_line": 1069,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_async",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1074,
+      "end_line": 1081,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#rebase_async",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1085,
+      "end_line": 1103,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_participants",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1105,
+      "end_line": 1113,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1115,
+      "end_line": 1117,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#raw_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1119,
+      "end_line": 1121,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_for_streaming",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1123,
+      "end_line": 1132,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_for_streaming_by_changed_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1134,
+      "end_line": 1137,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1139,
+      "end_line": 1148,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#non_latest_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1150,
+      "end_line": 1152,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#note_positions_for_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1154,
+      "end_line": 1169,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#preloads_discussion_diff_highlighting?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1171,
+      "end_line": 1173,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#discussions_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1175,
+      "end_line": 1184,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_stats",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1186,
+      "end_line": 1192,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_size",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1194,
+      "end_line": 1198,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#modified_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1200,
+      "end_line": 1208,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#changed_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1210,
+      "end_line": 1212,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#new_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1215,
+      "end_line": 1217,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1219,
+      "end_line": 1225,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_start_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1227,
+      "end_line": 1233,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_base_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1235,
+      "end_line": 1241,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1243,
+      "end_line": 1249,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merged_in_repository?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1251,
+      "end_line": 1253,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_commit_reachable_from_target_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1255,
+      "end_line": 1272,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_ref",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1280,
+      "end_line": 1285,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_ref",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1287,
+      "end_line": 1292,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1294,
+      "end_line": 1300,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1302,
+      "end_line": 1306,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#branch_merge_base_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1308,
+      "end_line": 1315,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1317,
+      "end_line": 1319,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1321,
+      "end_line": 1323,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1325,
+      "end_line": 1331,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#repository_diff_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1337,
+      "end_line": 1343,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#branch_merge_base_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1345,
+      "end_line": 1347,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#existing_mrs_targeting_same_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1349,
+      "end_line": 1359,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1361,
+      "end_line": 1381,
+      "value": 8
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#conflicting_mr_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1383,
+      "end_line": 1388,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_branch_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1390,
+      "end_line": 1398,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_branch_existence",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1400,
+      "end_line": 1410,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_target_project",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1412,
+      "end_line": 1416,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_fork",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1418,
+      "end_line": 1424,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#validate_reviewer_size_length",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1426,
+      "end_line": 1431,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_ongoing?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1433,
+      "end_line": 1439,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#closed_or_merged_without_fork?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1441,
+      "end_line": 1443,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_missing?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1445,
+      "end_line": 1450,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ensure_merge_request_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1452,
+      "end_line": 1456,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#create_merge_request_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1458,
+      "end_line": 1473,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_request_diff_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1475,
+      "end_line": 1490,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#previous_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1492,
+      "end_line": 1494,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#version_params_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1496,
+      "end_line": 1505,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#clear_memoized_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1507,
+      "end_line": 1513,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reload_diff_if_branch_changed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1515,
+      "end_line": 1520,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reload_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1523,
+      "end_line": 1528,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#check_mergeability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1530,
+      "end_line": 1540,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffable_merge_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1543,
+      "end_line": 1545,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recheck_merge_status?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1549,
+      "end_line": 1551,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_event",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1553,
+      "end_line": 1555,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#closed_event",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1557,
+      "end_line": 1559,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draft?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1561,
+      "end_line": 1563,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draftless_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1566,
+      "end_line": 1568,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#draft_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1571,
+      "end_line": 1573,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#skipped_auto_merge_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1576,
+      "end_line": 1601,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#auto_merge_eligible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1607,
+      "end_line": 1613,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1627,
+      "end_line": 1634,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.mergeable_state_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1636,
+      "end_line": 1638,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.mergeable_state_checks_by_tier",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1650,
+      "end_line": 1666,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.mergeable_git_state_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1668,
+      "end_line": 1673,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.all_mergeability_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1675,
+      "end_line": 1677,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1688,
+      "end_line": 1695,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable_git_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1698,
+      "end_line": 1705,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeability_checks_pass?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1708,
+      "end_line": 1714,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_mergeability_checks_results",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1716,
+      "end_line": 1721,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ff_merge_possible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1723,
+      "end_line": 1725,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#should_be_rebased?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1727,
+      "end_line": 1729,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_cancel_auto_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1731,
+      "end_line": 1733,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1735,
+      "end_line": 1741,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#should_remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1743,
+      "end_line": 1745,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#force_remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1747,
+      "end_line": 1749,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#auto_merge_strategy",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1751,
+      "end_line": 1755,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#default_auto_merge_strategy",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1757,
+      "end_line": 1759,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#auto_merge_strategy=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1761,
+      "end_line": 1763,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#remove_source_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1765,
+      "end_line": 1767,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#notify_conflict?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1769,
+      "end_line": 1778,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#related_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1780,
+      "end_line": 1788,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1792,
+      "end_line": 1800,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#duo_code_review_progress_note",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1802,
+      "end_line": 1804,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#mergeable_discussions_state?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1806,
+      "end_line": 1810,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#for_fork?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1812,
+      "end_line": 1814,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#for_same_project?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1816,
+      "end_line": 1818,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#cache_closing_issues_after_merge!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1820,
+      "end_line": 1837,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#cache_merge_request_closes_issues!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1844,
+      "end_line": 1858,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#visible_closing_issues_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1860,
+      "end_line": 1877,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#closes_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1880,
+      "end_line": 1892,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#issues_mentioned_but_not_closing",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1894,
+      "end_line": 1901,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#related_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1903,
+      "end_line": 1913,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_project_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1915,
+      "end_line": 1921,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1923,
+      "end_line": 1929,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1931,
+      "end_line": 1937,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_project_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1939,
+      "end_line": 1945,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#preload_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1947,
+      "end_line": 1956,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_branch_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1958,
+      "end_line": 1962,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1964,
+      "end_line": 1968,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#default_merge_commit_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1970,
+      "end_line": 1992,
+      "value": 8
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#default_squash_commit_message",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 1994,
+      "end_line": 1998,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_multiline_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2001,
+      "end_line": 2005,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_multiline_commit_description",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2008,
+      "end_line": 2013,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2015,
+      "end_line": 2020,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_ci?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2022,
+      "end_line": 2026,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#branch_missing?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2028,
+      "end_line": 2030,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#broken?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2032,
+      "end_line": 2034,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_be_merged_by?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2036,
+      "end_line": 2039,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#only_allow_merge_if_pipeline_succeeds?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2041,
+      "end_line": 2043,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allow_merge_without_pipeline?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2045,
+      "end_line": 2047,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#only_allow_merge_if_all_discussions_are_resolved?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2049,
+      "end_line": 2051,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_ci_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2054,
+      "end_line": 2056,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#pipeline_creating?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2058,
+      "end_line": 2060,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#environments_in_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2062,
+      "end_line": 2064,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#fetch_ref!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2066,
+      "end_line": 2069,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_ref_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2073,
+      "end_line": 2077,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ref_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2079,
+      "end_line": 2081,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_ref_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2083,
+      "end_line": 2085,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#train_ref_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2087,
+      "end_line": 2089,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#rebase_on_merge_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2091,
+      "end_line": 2093,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#schedule_cleanup_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2095,
+      "end_line": 2103,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#refs_to_cleanup",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2105,
+      "end_line": 2112,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#cleanup_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2114,
+      "end_line": 2116,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#async_cleanup_refs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2118,
+      "end_line": 2120,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.merge_request_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2122,
+      "end_line": 2124,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest.merge_train_ref?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2126,
+      "end_line": 2128,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#in_locked_state",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2130,
+      "end_line": 2144,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#force_unlock_and_close",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2160,
+      "end_line": 2164,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_and_mark_in_progress_merge_commit_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2166,
+      "end_line": 2172,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diverged_commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2174,
+      "end_line": 2187,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compute_diverged_commits_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2189,
+      "end_line": 2194,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diverged_from_target_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2197,
+      "end_line": 2199,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2201,
+      "end_line": 2205,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2207,
+      "end_line": 2218,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_test_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2220,
+      "end_line": 2222,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#predefined_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2225,
+      "end_line": 2247,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_test_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2250,
+      "end_line": 2256,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_accessibility_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2258,
+      "end_line": 2260,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_coverage_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2262,
+      "end_line": 2264,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_coverage_reports_for?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2266,
+      "end_line": 2268,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_terraform_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2270,
+      "end_line": 2272,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_accessibility_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2274,
+      "end_line": 2280,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_coverage_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2286,
+      "end_line": 2292,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_codequality_mr_diff_report?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2294,
+      "end_line": 2296,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_codequality_mr_diff_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2302,
+      "end_line": 2308,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_codequality_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2310,
+      "end_line": 2312,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_codequality_reports_for?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2314,
+      "end_line": 2316,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_codequality_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2318,
+      "end_line": 2326,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_terraform_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2328,
+      "end_line": 2334,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_exposed_artifacts?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2336,
+      "end_line": 2338,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_exposed_artifacts",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2344,
+      "end_line": 2350,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#compare_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2355,
+      "end_line": 2364,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_sast_reports?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2366,
+      "end_line": 2369,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#calculate_reactive_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2371,
+      "end_line": 2380,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_diff_head_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2384,
+      "end_line": 2389,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_commits",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2391,
+      "end_line": 2399,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_commit_shas",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2403,
+      "end_line": 2407,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2410,
+      "end_line": 2412,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2414,
+      "end_line": 2416,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merged_commit_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2418,
+      "end_line": 2423,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#short_merged_commit_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2425,
+      "end_line": 2429,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_to_revert",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2432,
+      "end_line": 2446,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_to_cherry_pick",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2448,
+      "end_line": 2450,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_be_reverted?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2452,
+      "end_line": 2467,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merged_at",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2469,
+      "end_line": 2478,
+      "value": 9
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_be_cherry_picked?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2480,
+      "end_line": 2482,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_complete_diff_refs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2484,
+      "end_line": 2486,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_diff_discussion_positions",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2489,
+      "end_line": 2525,
+      "value": 12
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#keep_around_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2528,
+      "end_line": 2532,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#enqueue_keep_around_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2534,
+      "end_line": 2543,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#async_keep_around_refs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2545,
+      "end_line": 2549,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_commits?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2551,
+      "end_line": 2553,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_no_commits?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2555,
+      "end_line": 2557,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#pipeline_coverage_delta",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2559,
+      "end_line": 2563,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#comparison_base_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2565,
+      "end_line": 2577,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_base_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2579,
+      "end_line": 2585,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#base_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2588,
+      "end_line": 2590,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#discussions_rendered_on_frontend?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2593,
+      "end_line": 2595,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#invalidate_project_counter_caches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2598,
+      "end_line": 2600,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_contribution?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2603,
+      "end_line": 2607,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allow_collaboration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2613,
+      "end_line": 2615,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#collaborative_push_possible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2619,
+      "end_line": 2624,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_allow_collaboration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2626,
+      "end_line": 2629,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_diff_head_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2631,
+      "end_line": 2633,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#real_time_notes_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2635,
+      "end_line": 2637,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#recent_visible_deployments",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2639,
+      "end_line": 2641,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#banzai_render_context",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2643,
+      "end_line": 2645,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ensure_metrics!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2647,
+      "end_line": 2649,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allows_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2651,
+      "end_line": 2653,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allows_multiple_assignees?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2655,
+      "end_line": 2657,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#allows_multiple_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2659,
+      "end_line": 2661,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reviewer_auto_assignment_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2663,
+      "end_line": 2665,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#supports_assignee?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2667,
+      "end_line": 2669,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#find_reviewer",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2671,
+      "end_line": 2673,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_request_reviewers_with",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2675,
+      "end_line": 2677,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#create_requested_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2679,
+      "end_line": 2681,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#destroy_requested_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2683,
+      "end_line": 2685,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#batch_update_reviewer_state",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2687,
+      "end_line": 2689,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#enabled_reports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2691,
+      "end_line": 2696,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#includes_ci_config?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2698,
+      "end_line": 2702,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#context_commits_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2704,
+      "end_line": 2708,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_default_branch?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2710,
+      "end_line": 2712,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_blocked_by_other_mrs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2714,
+      "end_line": 2716,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#execute_merge_checks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2718,
+      "end_line": 2724,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#can_suggest_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2726,
+      "end_line": 2728,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#hidden?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2730,
+      "end_line": 2732,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_batch_cache_with_max_age?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2734,
+      "end_line": 2736,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#prepared?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2738,
+      "end_line": 2740,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#initial_preparation?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2742,
+      "end_line": 2744,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#check_for_spam?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2746,
+      "end_line": 2748,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#missing_required_squash?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2750,
+      "end_line": 2752,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#current_patch_id_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2754,
+      "end_line": 2756,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diff_head_pipeline_considered_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2758,
+      "end_line": 2774,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#temporarily_unapproved?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2776,
+      "end_line": 2778,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_jira_issue_keys?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2780,
+      "end_line": 2788,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_exclusive_lease",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2790,
+      "end_line": 2794,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_and_target_branches_exist?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2796,
+      "end_line": 2798,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#has_diffs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2800,
+      "end_line": 2806,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#add_to_locked_set",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2808,
+      "end_line": 2810,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#remove_from_locked_set",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2812,
+      "end_line": 2814,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#first_diffs_slice",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2816,
+      "end_line": 2825,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#squash_option",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2827,
+      "end_line": 2829,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#log_approval_deletion_on_merged_or_locked_mr",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2833,
+      "end_line": 2847,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reached_versions_limit?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2849,
+      "end_line": 2851,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#reached_diff_commits_limit?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2853,
+      "end_line": 2860,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#diffs_batch_cache_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2862,
+      "end_line": 2867,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#commit_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2869,
+      "end_line": 2890,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#append_merge_params",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2917,
+      "end_line": 2922,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#clear_merge_params",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2924,
+      "end_line": 2929,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_merge_ref_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2931,
+      "end_line": 2943,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_merge_jid",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2945,
+      "end_line": 2957,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#ensure_merge_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2959,
+      "end_line": 2969,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#viewable_recent_merge_request_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2971,
+      "end_line": 2976,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#show_context_commits_diff?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2978,
+      "end_line": 2980,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_allow_broken",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 2988,
+      "end_line": 2994,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#state_changed_since_load?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3002,
+      "end_line": 3008,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#publish_code_conflict_event",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3010,
+      "end_line": 3013,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_emails_from_diff",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3015,
+      "end_line": 3034,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_emails_via_metadata_query",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3037,
+      "end_line": 3054,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#committer_emails_via_direct_query",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3056,
+      "end_line": 3065,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#update_cached_closing_issues_from_description!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3067,
+      "end_line": 3080,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#bulk_insert_cached_closing_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3082,
+      "end_line": 3099,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#merge_data_attributes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3101,
+      "end_line": 3117,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_merge_data_sync",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3119,
+      "end_line": 3140,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_single_transaction_merge_data_sync",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3142,
+      "end_line": 3156,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#save_merge_data_changes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3158,
+      "end_line": 3169,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#dual_write_to_merge_data_ff_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3171,
+      "end_line": 3173,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#viewable_diffs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3176,
+      "end_line": 3180,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#target_branch_pipelines_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3182,
+      "end_line": 3185,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#set_draft_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3187,
+      "end_line": 3189,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#expire_ancestor_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3191,
+      "end_line": 3193,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#missing_report_error",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3195,
+      "end_line": 3197,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_rebase_lock",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3199,
+      "end_line": 3201,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#with_retried_nowait_lock",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3207,
+      "end_line": 3217,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#source_project_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3219,
+      "end_line": 3229,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#expire_etag_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3231,
+      "end_line": 3236,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#report_type_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3238,
+      "end_line": 3248,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#truncate_mr_description",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3250,
+      "end_line": 3256,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#pipeline_has_report_in_self_or_descendants?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3258,
+      "end_line": 3262,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#all_commit_shas_from_metadata",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3264,
+      "end_line": 3281,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#resolve_diff_version",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3283,
+      "end_line": 3291,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#read_new_commits_table?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3293,
+      "end_line": 3295,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequest#project_id_pruning_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3298,
+      "end_line": 3300,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "MergeRequest",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 3,
+      "end_line": 3302,
+      "value": 2370
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "singleton_class",
+      "scope_name": "class << MergeRequest",
+      "path": "spec/fixtures/corpus/gitlab/app/models/merge_request.rb",
+      "start_line": 934,
+      "end_line": 938,
+      "value": 3
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/project.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/project.rb.json
@@ -1,0 +1,8162 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 445,
+        "max": 63.01,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Project#predefined_project_variables",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 2915,
+            "end_line": 2939,
+            "value": 63.01
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Project#predefined_ci_server_variables",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 2942,
+            "end_line": 2959,
+            "value": 50.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Project.sort_by_attribute",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 1271,
+            "end_line": 1300,
+            "value": 35.38
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Project#after_import",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 2734,
+            "end_line": 2754,
+            "value": 25.02
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Project#update_topics",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 3844,
+            "end_line": 3862,
+            "value": 20.86
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 445,
+        "max": 25,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Project.sort_by_attribute",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 1271,
+            "end_line": 1300,
+            "value": 25
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Project#protected_for?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 3023,
+            "end_line": 3040,
+            "value": 8
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Project#import?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 1876,
+            "end_line": 1878,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Project#notify_project_import_complete?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 1884,
+            "end_line": 1888,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Project#update_topics",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 3844,
+            "end_line": 3862,
+            "value": 7
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 3081,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Project",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 5,
+            "end_line": 4145,
+            "value": 3081
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "singleton_class",
+            "scope_name": "class << Project",
+            "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+            "start_line": 1243,
+            "end_line": 1414,
+            "value": 129
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.integration_association_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 221,
+      "end_line": 223,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#with_developer_access",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 419,
+      "end_line": 421,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.with_api_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1077,
+      "end_line": 1080,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.with_web_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1082,
+      "end_line": 1085,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.with_api_commit_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1087,
+      "end_line": 1089,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.with_api_blob_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1091,
+      "end_line": 1093,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.with_slack_application_disabled",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1095,
+      "end_line": 1107,
+      "value": 20.02
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.eager_load_namespace_and_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1109,
+      "end_line": 1111,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.public_or_visible_to_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1115,
+      "end_line": 1129,
+      "value": 9.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.public_non_forked_or_visible_to_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1134,
+      "end_line": 1144,
+      "value": 8.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.visibility_levels_for_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1149,
+      "end_line": 1155,
+      "value": 4.36
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.cascading_with_parent_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1163,
+      "end_line": 1171,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.with_feature_available_for_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1178,
+      "end_line": 1180,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.projects_user_can",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1182,
+      "end_line": 1186,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.filter_out_public_projects_with_unauthorized_private_repos",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1188,
+      "end_line": 1205,
+      "value": 9.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.filter_by_feature_visibility",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1208,
+      "end_line": 1214,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.wrap_with_cte",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1216,
+      "end_line": 1219,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.dormant",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1221,
+      "end_line": 1229,
+      "value": 11.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1250,
+      "end_line": 1260,
+      "value": 9.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.search_by_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1262,
+      "end_line": 1264,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.visibility_levels",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1266,
+      "end_line": 1268,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.sort_by_attribute",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1271,
+      "end_line": 1300,
+      "value": 35.38
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1303,
+      "end_line": 1310,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.reference_postfix",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1312,
+      "end_line": 1314,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.reference_postfix_escaped",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1316,
+      "end_line": 1318,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.markdown_reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1323,
+      "end_line": 1329,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.cached_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1331,
+      "end_line": 1335,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.group_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1337,
+      "end_line": 1339,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.ids_with_issuables_available_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1345,
+      "end_line": 1350,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.find_by_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1352,
+      "end_line": 1365,
+      "value": 18.14
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.without_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1367,
+      "end_line": 1377,
+      "value": 8.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.project_features_defaults",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1379,
+      "end_line": 1381,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.by_pages_enabled_unique_domain",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1383,
+      "end_line": 1390,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.project_namespace_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1392,
+      "end_line": 1394,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.group_by_namespace_traversal_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1396,
+      "end_line": 1402,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project.root_ids_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1404,
+      "end_line": 1413,
+      "value": 6.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#initialize",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1416,
+      "end_line": 1427,
+      "value": 4.69
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#owner_entity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1429,
+      "end_line": 1431,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#owner_entity_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1433,
+      "end_line": 1435,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#set_project_feature_defaults",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1438,
+      "end_line": 1445,
+      "value": 8.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#resource_parent",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1447,
+      "end_line": 1449,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#certificate_based_clusters_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1451,
+      "end_line": 1453,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#jenkins_integration_active?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1455,
+      "end_line": 1457,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#service_accounts",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1459,
+      "end_line": 1461,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#personal_namespace_holder?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1463,
+      "end_line": 1473,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#invalidate_personal_projects_count_of_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1475,
+      "end_line": 1480,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#project_setting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1482,
+      "end_line": 1484,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#show_default_award_emojis?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1486,
+      "end_line": 1488,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#enforce_auth_checks_on_uploads?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1490,
+      "end_line": 1492,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#warn_about_potentially_unwanted_characters?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1494,
+      "end_line": 1496,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#extended_prat_expiry_webhooks_execute?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1498,
+      "end_line": 1500,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#no_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1502,
+      "end_line": 1504,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_scheduled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1506,
+      "end_line": 1508,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_started?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1510,
+      "end_line": 1512,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1514,
+      "end_line": 1516,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_failed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1518,
+      "end_line": 1520,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_finished?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1522,
+      "end_line": 1524,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#all_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1526,
+      "end_line": 1532,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1534,
+      "end_line": 1540,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#active_webide_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1542,
+      "end_line": 1544,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#default_pipeline_lock",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1546,
+      "end_line": 1552,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#autoclose_referenced_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1554,
+      "end_line": 1558,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#preload_protected_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1560,
+      "end_line": 1565,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_upto",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1569,
+      "end_line": 1572,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1574,
+      "end_line": 1576,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_and_ancestors_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1579,
+      "end_line": 1583,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_upto_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1585,
+      "end_line": 1587,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#emails_disabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1589,
+      "end_line": 1592,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1595,
+      "end_line": 1599,
+      "value": 8.25
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#auto_devops_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1603,
+      "end_line": 1609,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_auto_devops_implicitly_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1611,
+      "end_line": 1615,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#packages_cleanup_policy",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1617,
+      "end_line": 1619,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#first_auto_devops_config",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1621,
+      "end_line": 1625,
+      "value": 8.94
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#design_management_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1628,
+      "end_line": 1630,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#team",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1632,
+      "end_line": 1634,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1637,
+      "end_line": 1639,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#find_or_create_design_management_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1641,
+      "end_line": 1643,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#design_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1645,
+      "end_line": 1649,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#cleanup",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1651,
+      "end_line": 1653,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#container_registry_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1657,
+      "end_line": 1661,
+      "value": 8.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#container_repositories_size",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1663,
+      "end_line": 1670,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_container_registry_tags?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1672,
+      "end_line": 1677,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_build_for_ref",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1680,
+      "end_line": 1687,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_build_for_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1689,
+      "end_line": 1696,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_build_for_ref!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1698,
+      "end_line": 1700,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1702,
+      "end_line": 1708,
+      "value": 9.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_unscheduled_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1710,
+      "end_line": 1716,
+      "value": 9.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_unscheduled_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1718,
+      "end_line": 1720,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1722,
+      "end_line": 1724,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_pipeline_for_ci_and_security_orchestration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1726,
+      "end_line": 1728,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_base_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1730,
+      "end_line": 1735,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#saved?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1737,
+      "end_line": 1739,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1741,
+      "end_line": 1743,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_checksums",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1745,
+      "end_line": 1747,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#jira_import_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1749,
+      "end_line": 1751,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#human_import_status_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1753,
+      "end_line": 1755,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#beautified_import_status_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1757,
+      "end_line": 1767,
+      "value": 13.75
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#add_import_job",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1769,
+      "end_line": 1780,
+      "value": 6.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#log_import_activity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1782,
+      "end_line": 1791,
+      "value": 9.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#reset_cache_and_import_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1793,
+      "end_line": 1800,
+      "value": 6.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#remove_import_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1803,
+      "end_line": 1805,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_config_path=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1807,
+      "end_line": 1810,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#commit_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1813,
+      "end_line": 1815,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#safe_import_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1827,
+      "end_line": 1830,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_url=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1832,
+      "end_line": 1844,
+      "value": 9.95
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#unsafe_import_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1857,
+      "end_line": 1865,
+      "value": 10.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#build_or_assign_import_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1867,
+      "end_line": 1874,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1876,
+      "end_line": 1878,
+      "value": 10.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#external_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1880,
+      "end_line": 1882,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#notify_project_import_complete?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1884,
+      "end_line": 1888,
+      "value": 10.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#jira_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1890,
+      "end_line": 1892,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#gitlab_project_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1894,
+      "end_line": 1896,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#gitlab_project_migration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1898,
+      "end_line": 1900,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#offline_transfer?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1902,
+      "end_line": 1904,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#transfer_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1908,
+      "end_line": 1910,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#gitea_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1912,
+      "end_line": 1914,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#github_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1916,
+      "end_line": 1918,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#bitbucket_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1920,
+      "end_line": 1922,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#bitbucket_server_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1924,
+      "end_line": 1926,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#github_enterprise_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1928,
+      "end_line": 1931,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#any_import_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1937,
+      "end_line": 1943,
+      "value": 10.82
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_remote_mirror?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1945,
+      "end_line": 1947,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#updating_remote_mirror?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1949,
+      "end_line": 1951,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#update_remote_mirrors",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1953,
+      "end_line": 1957,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#mark_stuck_remote_mirrors_as_failed!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1959,
+      "end_line": 1965,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#mark_remote_mirrors_for_removal",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1967,
+      "end_line": 1969,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#remote_mirror_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1971,
+      "end_line": 1974,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#check_personal_projects_limit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1976,
+      "end_line": 1992,
+      "value": 14.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#should_validate_visibility_level?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1994,
+      "end_line": 1996,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_by_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1998,
+      "end_line": 2006,
+      "value": 15.43
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_as_fork",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2008,
+      "end_line": 2013,
+      "value": 8.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_https_only",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2015,
+      "end_line": 2019,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_https_only?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2021,
+      "end_line": 2025,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#validate_pages_https_only",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2027,
+      "end_line": 2033,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#changing_shared_runners_enabled_is_allowed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2035,
+      "end_line": 2041,
+      "value": 7.62
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#parent_organization_match",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2043,
+      "end_line": 2048,
+      "value": 7.62
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#shared_runners_setting_conflicting_with_group?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2050,
+      "end_line": 2052,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#reconcile_shared_runners_setting!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2054,
+      "end_line": 2058,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#to_param",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2060,
+      "end_line": 2066,
+      "value": 5.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#to_reference",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2074,
+      "end_line": 2077,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#to_reference_base",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2080,
+      "end_line": 2086,
+      "value": 6.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#to_human_reference",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2088,
+      "end_line": 2094,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#readme_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2096,
+      "end_line": 2101,
+      "value": 6.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#new_issuable_address",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2103,
+      "end_line": 2116,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#build_commit_note",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2118,
+      "end_line": 2120,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#last_activity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2122,
+      "end_line": 2124,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#project_id",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2126,
+      "end_line": 2128,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#get_issue",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2130,
+      "end_line": 2138,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#issue_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2140,
+      "end_line": 2142,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#external_issue_reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2144,
+      "end_line": 2146,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#default_issues_tracker?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2148,
+      "end_line": 2150,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#external_issue_tracker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2152,
+      "end_line": 2158,
+      "value": 7.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#external_references_supported?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2160,
+      "end_line": 2162,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_wiki?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2164,
+      "end_line": 2166,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#external_wiki",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2168,
+      "end_line": 2174,
+      "value": 7.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#find_or_initialize_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2176,
+      "end_line": 2182,
+      "value": 8.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#disabled_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2186,
+      "end_line": 2188,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#find_or_initialize_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2190,
+      "end_line": 2195,
+      "value": 8.94
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#create_labels",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2198,
+      "end_line": 2206,
+      "value": 10.25
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2209,
+      "end_line": 2211,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2213,
+      "end_line": 2215,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#avatar_in_git",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2217,
+      "end_line": 2219,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#avatar_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2221,
+      "end_line": 2223,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#code",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2226,
+      "end_line": 2228,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#all_clusters",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2230,
+      "end_line": 2235,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#items_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2237,
+      "end_line": 2244,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#send_move_instructions",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2247,
+      "end_line": 2253,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2256,
+      "end_line": 2261,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#deprecated_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2263,
+      "end_line": 2267,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#owners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2269,
+      "end_line": 2274,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#first_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2276,
+      "end_line": 2284,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#execute_hooks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2287,
+      "end_line": 2292,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#triggered_hooks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2295,
+      "end_line": 2309,
+      "value": 8.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#execute_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2311,
+      "end_line": 2320,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#execute_flow_triggers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2322,
+      "end_line": 2324,
+      "value": 0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_active_hooks?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2326,
+      "end_line": 2334,
+      "value": 10.05
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_active_integrations?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2336,
+      "end_line": 2342,
+      "value": 6.63
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#feature_usage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2344,
+      "end_line": 2346,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#forked?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2348,
+      "end_line": 2350,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#fork_source",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2352,
+      "end_line": 2356,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#valid_lfs_oids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2358,
+      "end_line": 2360,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_objects_for_repository_types",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2362,
+      "end_line": 2366,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_objects_oids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2368,
+      "end_line": 2370,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_objects_oids_from_fork_source",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2372,
+      "end_line": 2376,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#personal?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2378,
+      "end_line": 2380,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#expire_caches_before_rename",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2383,
+      "end_line": 2391,
+      "value": 11.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#check_repository_path_availability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2394,
+      "end_line": 2408,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#track_project_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2415,
+      "end_line": 2428,
+      "value": 16.97
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#create_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2430,
+      "end_line": 2442,
+      "value": 13.38
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2444,
+      "end_line": 2471,
+      "value": 18.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#member",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2473,
+      "end_line": 2479,
+      "value": 9.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#membership_locked?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2482,
+      "end_line": 2484,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#bots",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2486,
+      "end_line": 2488,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#members_among",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2491,
+      "end_line": 2500,
+      "value": 14.46
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_field",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2502,
+      "end_line": 2504,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#after_repository_change_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2507,
+      "end_line": 2511,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#forked_from?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2513,
+      "end_line": 2515,
+      "value": 2.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#in_fork_network_of?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2517,
+      "end_line": 2521,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#origin_merge_requests",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2523,
+      "end_line": 2525,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2527,
+      "end_line": 2529,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#allowed_to_share_with_group?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2532,
+      "end_line": 2534,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#share_with_group_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2536,
+      "end_line": 2538,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_pipeline_for_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2540,
+      "end_line": 2547,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2549,
+      "end_line": 2551,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#builds_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2553,
+      "end_line": 2555,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#wiki_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2557,
+      "end_line": 2559,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_requests_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2561,
+      "end_line": 2563,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#forking_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2565,
+      "end_line": 2567,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#issues_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2569,
+      "end_line": 2571,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2573,
+      "end_line": 2575,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#analytics_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2577,
+      "end_line": 2579,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#snippets_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2581,
+      "end_line": 2583,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#public_pages?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2585,
+      "end_line": 2587,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#private_pages?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2589,
+      "end_line": 2594,
+      "value": 8.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_access_control_forced_by_ancestor?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2596,
+      "end_line": 2600,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#operations_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2602,
+      "end_line": 2604,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#container_registry_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2606,
+      "end_line": 2608,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#enable_ci",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2611,
+      "end_line": 2613,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#shared_runners_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2615,
+      "end_line": 2617,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#shared_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2619,
+      "end_line": 2621,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#available_shared_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2623,
+      "end_line": 2625,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#group_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2627,
+      "end_line": 2629,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#all_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2631,
+      "end_line": 2633,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#all_available_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2635,
+      "end_line": 2637,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#active_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2639,
+      "end_line": 2643,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#any_online_runners?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2645,
+      "end_line": 2647,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#valid_runners_token?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2649,
+      "end_line": 2651,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#open_issues_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2654,
+      "end_line": 2664,
+      "value": 10.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#open_merge_requests_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2668,
+      "end_line": 2674,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_as_fork?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2677,
+      "end_line": 2684,
+      "value": 4.36
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_by_namespace?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2686,
+      "end_line": 2691,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2693,
+      "end_line": 2695,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#runners_token",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2697,
+      "end_line": 2701,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_deployed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2703,
+      "end_line": 2705,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_show_onboarding?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2707,
+      "end_line": 2709,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_unique_domain_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2711,
+      "end_line": 2713,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#remove_private_deploy_keys",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2715,
+      "end_line": 2728,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#mark_pages_onboarding_complete",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2730,
+      "end_line": 2732,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#after_import",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2734,
+      "end_line": 2754,
+      "value": 25.02
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#reset_counters_and_iids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2756,
+      "end_line": 2764,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#update_project_counter_caches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2766,
+      "end_line": 2776,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#after_create_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2779,
+      "end_line": 2781,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pipeline_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2785,
+      "end_line": 2787,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#add_export_job",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2789,
+      "end_line": 2803,
+      "value": 11.36
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_export_shared",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2805,
+      "end_line": 2807,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2809,
+      "end_line": 2813,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2815,
+      "end_line": 2829,
+      "value": 7.81
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2831,
+      "end_line": 2835,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_enqueued?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2837,
+      "end_line": 2841,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_failed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2843,
+      "end_line": 2847,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#regeneration_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2849,
+      "end_line": 2851,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#remove_exports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2853,
+      "end_line": 2860,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#remove_export_for_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2862,
+      "end_line": 2868,
+      "value": 5.92
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#import_export_upload_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2870,
+      "end_line": 2872,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_file_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2874,
+      "end_line": 2876,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_archive_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2878,
+      "end_line": 2880,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#export_file",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2882,
+      "end_line": 2884,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#full_path_slug",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2886,
+      "end_line": 2888,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_ci?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2890,
+      "end_line": 2892,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_ci_config_file?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2894,
+      "end_line": 2898,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#predefined_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2900,
+      "end_line": 2912,
+      "value": 18.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#predefined_project_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2915,
+      "end_line": 2939,
+      "value": 63.01
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#predefined_ci_server_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2942,
+      "end_line": 2959,
+      "value": 50.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2961,
+      "end_line": 2969,
+      "value": 9.11
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#api_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2971,
+      "end_line": 2976,
+      "value": 8.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_template_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2978,
+      "end_line": 2982,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#dependency_proxy_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2984,
+      "end_line": 3000,
+      "value": 18.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#container_registry_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3002,
+      "end_line": 3012,
+      "value": 12.21
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#default_environment",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3014,
+      "end_line": 3021,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#protected_for?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3023,
+      "end_line": 3040,
+      "value": 15.13
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#deployment_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3042,
+      "end_line": 3052,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#auto_devops_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3054,
+      "end_line": 3058,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#route_map_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3060,
+      "end_line": 3072,
+      "value": 8.37
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#public_path_for_source_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3074,
+      "end_line": 3079,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#parent_changed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3081,
+      "end_line": 3083,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#default_merge_request_target",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3085,
+      "end_line": 3090,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#mr_can_target_upstream?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3092,
+      "end_line": 3098,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#multiple_issue_boards_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3100,
+      "end_line": 3102,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#full_path_before_last_save",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3104,
+      "end_line": 3106,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#forks_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3114,
+      "end_line": 3122,
+      "value": 7.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#legacy_storage?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3125,
+      "end_line": 3127,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#hashed_storage?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3132,
+      "end_line": 3136,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#archived",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3138,
+      "end_line": 3140,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_or_ancestors_archived?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3144,
+      "end_line": 3146,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_archived?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3148,
+      "end_line": 3150,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_and_ancestors_active?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3152,
+      "end_line": 3154,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_or_ancestors_transfer_scheduled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3156,
+      "end_line": 3158,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_or_ancestors_transfer_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3160,
+      "end_line": 3162,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#renamed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3164,
+      "end_line": 3166,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#human_merge_method",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3168,
+      "end_line": 3174,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_method",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3176,
+      "end_line": 3184,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#can_create_new_ref_commits?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3186,
+      "end_line": 3188,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_method=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3190,
+      "end_line": 3202,
+      "value": 9.7
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ff_merge_must_be_possible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3204,
+      "end_line": 3206,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#git_transfer_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3209,
+      "end_line": 3213,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#storage_version=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3215,
+      "end_line": 3219,
+      "value": 1.73
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#badges",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3221,
+      "end_line": 3225,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_requests_allowing_push_to_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3227,
+      "end_line": 3236,
+      "value": 8.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#any_branch_allows_collaboration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3238,
+      "end_line": 3240,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#branch_allows_collaboration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3242,
+      "end_line": 3244,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#external_authorization_classification_label",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3246,
+      "end_line": 3249,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#licensed_feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3252,
+      "end_line": 3254,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#licensed_features",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3256,
+      "end_line": 3258,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#toggle_ci_cd_settings!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3260,
+      "end_line": 3262,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#gitlab_deploy_token",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3264,
+      "end_line": 3268,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#any_lfs_file_locks?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3270,
+      "end_line": 3272,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#auto_cancel_pending_pipelines?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3275,
+      "end_line": 3277,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#storage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3279,
+      "end_line": 3286,
+      "value": 4.36
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#snippets_visible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3288,
+      "end_line": 3290,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#max_attachment_size",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3292,
+      "end_line": 3294,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#git_objects_poolable?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3302,
+      "end_line": 3308,
+      "value": 7.81
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#leave_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3310,
+      "end_line": 3317,
+      "value": 8.06
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#swap_pool_repository!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3320,
+      "end_line": 3331,
+      "value": 13.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#link_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3333,
+      "end_line": 3338,
+      "value": 8.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_pool_repository?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3340,
+      "end_line": 3342,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#access_request_approvers_to_be_notified",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3344,
+      "end_line": 3354,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#closest_setting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3356,
+      "end_line": 3361,
+      "value": 6.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#drop_visibility_level!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3363,
+      "end_line": 3371,
+      "value": 11.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#template_source?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3373,
+      "end_line": 3375,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#jira_subscription_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3377,
+      "end_line": 3379,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#group_protected_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3381,
+      "end_line": 3385,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#default_branch_protected?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3387,
+      "end_line": 3391,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#environments_for_scope",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3393,
+      "end_line": 3397,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#batch_loaded_environment_by_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3399,
+      "end_line": 3408,
+      "value": 8.94
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#latest_jira_import",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3410,
+      "end_line": 3412,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#root_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3414,
+      "end_line": 3420,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#root_group",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3422,
+      "end_line": 3426,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#related_group_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3428,
+      "end_line": 3434,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#default_branch_or_main",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3436,
+      "end_line": 3440,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_config_path_or_default",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3442,
+      "end_line": 3444,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_config_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3446,
+      "end_line": 3448,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#feature_flags_client_token",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3450,
+      "end_line": 3453,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#git_garbage_collect_worker_klass",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3456,
+      "end_line": 3458,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_display_pipeline_variables?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3460,
+      "end_line": 3464,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_skip_branch_pipelines_for_mrs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3466,
+      "end_line": 3470,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_forward_deployment_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3472,
+      "end_line": 3476,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_forward_deployment_rollback_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3478,
+      "end_line": 3482,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_allow_fork_pipelines_to_run_in_parent_project?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3484,
+      "end_line": 3488,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_outbound_job_token_scope_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3490,
+      "end_line": 3494,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_inbound_job_token_scope_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3496,
+      "end_line": 3502,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#restrict_user_defined_variables?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3504,
+      "end_line": 3508,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#override_pipeline_variables_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3510,
+      "end_line": 3514,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_push_repository_for_job_token_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3516,
+      "end_line": 3520,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ci_cross_project_push_for_job_token_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3522,
+      "end_line": 3526,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#keep_latest_artifacts_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3528,
+      "end_line": 3532,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#keep_latest_artifact?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3534,
+      "end_line": 3538,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#group_runners_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3540,
+      "end_line": 3544,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#topic_list",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3546,
+      "end_line": 3548,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#after_change_head_branch_does_not_exist",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3551,
+      "end_line": 3553,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#visible_group_links",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3555,
+      "end_line": 3563,
+      "value": 8.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#parent_groups",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3565,
+      "end_line": 3567,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#enforced_runner_token_expiration_interval",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3569,
+      "end_line": 3577,
+      "value": 10.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_commit_template_or_default",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3579,
+      "end_line": 3581,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_commit_template_or_default=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3583,
+      "end_line": 3590,
+      "value": 5.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#squash_commit_template_or_default",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3592,
+      "end_line": 3594,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#squash_commit_template_or_default=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3596,
+      "end_line": 3603,
+      "value": 5.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_deletion_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3607,
+      "end_line": 3609,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#self_deletion_in_progress_or_hidden?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3611,
+      "end_line": 3613,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#work_item_tasks_on_boards_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3615,
+      "end_line": 3617,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#glql_load_on_click_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3619,
+      "end_line": 3621,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#markdown_placeholders_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3623,
+      "end_line": 3625,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#allow_iframes_in_markdown_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3627,
+      "end_line": 3629,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#sscs_malware_detection_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3631,
+      "end_line": 3633,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#use_work_item_url?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3635,
+      "end_line": 3640,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#enqueue_record_project_target_platforms",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3642,
+      "end_line": 3646,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#dormant?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3648,
+      "end_line": 3651,
+      "value": 9.85
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#refreshing_build_artifacts_size?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3653,
+      "end_line": 3655,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#group_group_links",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3657,
+      "end_line": 3659,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#security_training_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3661,
+      "end_line": 3663,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#packages_policy_subject",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3665,
+      "end_line": 3667,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#destroy_deployment_by_id",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3669,
+      "end_line": 3671,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#can_create_custom_domains?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3673,
+      "end_line": 3677,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_domain_present?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3679,
+      "end_line": 3681,
+      "value": 5.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#can_suggest_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3684,
+      "end_line": 3686,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#suggested_reviewers_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3689,
+      "end_line": 3691,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#crm_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3693,
+      "end_line": 3697,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#crm_group",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3699,
+      "end_line": 3703,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#supports_lock_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3705,
+      "end_line": 3707,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#path_availability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3709,
+      "end_line": 3716,
+      "value": 10.95
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#repository_object_format",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3718,
+      "end_line": 3720,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#instance_runner_running_jobs_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3722,
+      "end_line": 3726,
+      "value": 7.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#allows_multiple_merge_request_assignees?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3730,
+      "end_line": 3732,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#allows_multiple_merge_request_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3735,
+      "end_line": 3737,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#on_demand_dast_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3740,
+      "end_line": 3742,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#supports_saved_replies?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3745,
+      "end_line": 3747,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_trains_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3750,
+      "end_line": 3752,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_file_locks_changed_epoch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3754,
+      "end_line": 3756,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#refresh_lfs_file_locks_changed_epoch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3758,
+      "end_line": 3760,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#placeholder_reference_store",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3762,
+      "end_line": 3769,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3771,
+      "end_line": 3773,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_hostname",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3775,
+      "end_line": 3777,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#uploads_sharding_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3779,
+      "end_line": 3781,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pages_url_builder",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3783,
+      "end_line": 3787,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_container_registry_protected_tag_rules?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3789,
+      "end_line": 3793,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#licensed_ai_features_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3796,
+      "end_line": 3798,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3801,
+      "end_line": 3803,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#check_duplicate_export!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3807,
+      "end_line": 3811,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#with_redis",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3813,
+      "end_line": 3815,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_file_locks_changed_epoch_cache_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3817,
+      "end_line": 3819,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#get_epoch_from",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3821,
+      "end_line": 3823,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#refresh_epoch_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3825,
+      "end_line": 3831,
+      "value": 6.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#project_group_links_with_preload",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3834,
+      "end_line": 3836,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#save_topics",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3838,
+      "end_line": 3842,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#update_topics",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3844,
+      "end_line": 3862,
+      "value": 20.86
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#find_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3864,
+      "end_line": 3866,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#build_from_instance",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3868,
+      "end_line": 3874,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#build_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3876,
+      "end_line": 3878,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#integration_instances",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3880,
+      "end_line": 3882,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#closest_namespace_setting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3884,
+      "end_line": 3886,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#app_settings_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3888,
+      "end_line": 3890,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#merge_requests_allowing_collaboration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3892,
+      "end_line": 3896,
+      "value": 5.48
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#create_new_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3898,
+      "end_line": 3910,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#join_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3912,
+      "end_line": 3916,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#use_hashed_storage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3918,
+      "end_line": 3922,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#check_repository_absence!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3924,
+      "end_line": 3931,
+      "value": 8.54
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#repository_with_same_path_already_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3933,
+      "end_line": 3935,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#set_timestamps_for_create",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3937,
+      "end_line": 3939,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#cross_namespace_reference?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3941,
+      "end_line": 3952,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#cross_project_reference?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3955,
+      "end_line": 3964,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#update_project_statistics",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3966,
+      "end_line": 3969,
+      "value": 4.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#check_pending_delete",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3971,
+      "end_line": 3980,
+      "value": 9.9
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pending_delete_twin",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3982,
+      "end_line": 3986,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#has_root_container_repository_tags?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3993,
+      "end_line": 3997,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#fetch_branch_allows_collaboration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3999,
+      "end_line": 4013,
+      "value": 11.22
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_pages_metadatum",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4015,
+      "end_line": 4020,
+      "value": 3.61
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#oids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4022,
+      "end_line": 4028,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#cache_has_external_wiki",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4030,
+      "end_line": 4032,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#cache_has_external_issue_tracker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4034,
+      "end_line": 4036,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#online_runners_with_tags",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4038,
+      "end_line": 4040,
+      "value": 3.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_project_namespace_in_sync",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4042,
+      "end_line": 4047,
+      "value": 5.39
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#project_namespace_creation_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4049,
+      "end_line": 4051,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#sync_project_namespace?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4053,
+      "end_line": 4055,
+      "value": 6.08
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#reload_project_namespace_details",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4057,
+      "end_line": 4061,
+      "value": 10.2
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#schedule_sync_event_worker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4064,
+      "end_line": 4068,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#check_project_export_limit!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4070,
+      "end_line": 4076,
+      "value": 9.85
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#remove_leading_spaces_on_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4078,
+      "end_line": 4080,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#set_last_activity_at",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4082,
+      "end_line": 4090,
+      "value": 11.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#set_package_registry_access_level",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4092,
+      "end_line": 4096,
+      "value": 8.6
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#enabled_package_registry_access_level_by_project_visibility",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4098,
+      "end_line": 4107,
+      "value": 2.24
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#runners_token_prefix",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4109,
+      "end_line": 4111,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#pool_repository_shard_matches_repository?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4113,
+      "end_line": 4117,
+      "value": 3.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#enqueue_catalog_resource_sync_event_worker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4120,
+      "end_line": 4124,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_scheduled_for_deletion",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4128,
+      "end_line": 4136,
+      "value": 9.27
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#validate_unsafe_import_url?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4138,
+      "end_line": 4140,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Project#unique_attributes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4142,
+      "end_line": 4144,
+      "value": 0.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.integration_association_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 221,
+      "end_line": 223,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#with_developer_access",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 419,
+      "end_line": 421,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.with_api_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1077,
+      "end_line": 1080,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.with_web_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1082,
+      "end_line": 1085,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.with_api_commit_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1087,
+      "end_line": 1089,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.with_api_blob_entity_associations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1091,
+      "end_line": 1093,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.with_slack_application_disabled",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1095,
+      "end_line": 1107,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.eager_load_namespace_and_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1109,
+      "end_line": 1111,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.public_or_visible_to_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1115,
+      "end_line": 1129,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.public_non_forked_or_visible_to_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1134,
+      "end_line": 1144,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.visibility_levels_for_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1149,
+      "end_line": 1155,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.cascading_with_parent_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1163,
+      "end_line": 1171,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.with_feature_available_for_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1178,
+      "end_line": 1180,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.projects_user_can",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1182,
+      "end_line": 1186,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.filter_out_public_projects_with_unauthorized_private_repos",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1188,
+      "end_line": 1205,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.filter_by_feature_visibility",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1208,
+      "end_line": 1214,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.wrap_with_cte",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1216,
+      "end_line": 1219,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.dormant",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1221,
+      "end_line": 1229,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.search",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1250,
+      "end_line": 1260,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.search_by_title",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1262,
+      "end_line": 1264,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.visibility_levels",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1266,
+      "end_line": 1268,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.sort_by_attribute",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1271,
+      "end_line": 1300,
+      "value": 25
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1303,
+      "end_line": 1310,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.reference_postfix",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1312,
+      "end_line": 1314,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.reference_postfix_escaped",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1316,
+      "end_line": 1318,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.markdown_reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1323,
+      "end_line": 1329,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.cached_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1331,
+      "end_line": 1335,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.group_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1337,
+      "end_line": 1339,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.ids_with_issuables_available_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1345,
+      "end_line": 1350,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.find_by_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1352,
+      "end_line": 1365,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.without_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1367,
+      "end_line": 1377,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.project_features_defaults",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1379,
+      "end_line": 1381,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.by_pages_enabled_unique_domain",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1383,
+      "end_line": 1390,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.project_namespace_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1392,
+      "end_line": 1394,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.group_by_namespace_traversal_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1396,
+      "end_line": 1402,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project.root_ids_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1404,
+      "end_line": 1413,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#initialize",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1416,
+      "end_line": 1427,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#owner_entity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1429,
+      "end_line": 1431,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#owner_entity_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1433,
+      "end_line": 1435,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#set_project_feature_defaults",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1438,
+      "end_line": 1445,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#resource_parent",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1447,
+      "end_line": 1449,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#certificate_based_clusters_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1451,
+      "end_line": 1453,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#jenkins_integration_active?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1455,
+      "end_line": 1457,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#service_accounts",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1459,
+      "end_line": 1461,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#personal_namespace_holder?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1463,
+      "end_line": 1473,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#invalidate_personal_projects_count_of_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1475,
+      "end_line": 1480,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#project_setting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1482,
+      "end_line": 1484,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#show_default_award_emojis?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1486,
+      "end_line": 1488,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#enforce_auth_checks_on_uploads?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1490,
+      "end_line": 1492,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#warn_about_potentially_unwanted_characters?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1494,
+      "end_line": 1496,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#extended_prat_expiry_webhooks_execute?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1498,
+      "end_line": 1500,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#no_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1502,
+      "end_line": 1504,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_scheduled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1506,
+      "end_line": 1508,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_started?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1510,
+      "end_line": 1512,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1514,
+      "end_line": 1516,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_failed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1518,
+      "end_line": 1520,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_finished?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1522,
+      "end_line": 1524,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#all_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1526,
+      "end_line": 1532,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1534,
+      "end_line": 1540,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#active_webide_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1542,
+      "end_line": 1544,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#default_pipeline_lock",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1546,
+      "end_line": 1552,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#autoclose_referenced_issues",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1554,
+      "end_line": 1558,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#preload_protected_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1560,
+      "end_line": 1565,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_upto",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1569,
+      "end_line": 1572,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1574,
+      "end_line": 1576,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_and_ancestors_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1579,
+      "end_line": 1583,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_upto_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1585,
+      "end_line": 1587,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#emails_disabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1589,
+      "end_line": 1592,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1595,
+      "end_line": 1599,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#auto_devops_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1603,
+      "end_line": 1609,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_auto_devops_implicitly_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1611,
+      "end_line": 1615,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#packages_cleanup_policy",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1617,
+      "end_line": 1619,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#first_auto_devops_config",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1621,
+      "end_line": 1625,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#design_management_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1628,
+      "end_line": 1630,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#team",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1632,
+      "end_line": 1634,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1637,
+      "end_line": 1639,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#find_or_create_design_management_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1641,
+      "end_line": 1643,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#design_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1645,
+      "end_line": 1649,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#cleanup",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1651,
+      "end_line": 1653,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#container_registry_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1657,
+      "end_line": 1661,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#container_repositories_size",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1663,
+      "end_line": 1670,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_container_registry_tags?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1672,
+      "end_line": 1677,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_build_for_ref",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1680,
+      "end_line": 1687,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_build_for_sha",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1689,
+      "end_line": 1696,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_build_for_ref!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1698,
+      "end_line": 1700,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1702,
+      "end_line": 1708,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_unscheduled_pipelines",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1710,
+      "end_line": 1716,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_unscheduled_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1718,
+      "end_line": 1720,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_pipeline",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1722,
+      "end_line": 1724,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_pipeline_for_ci_and_security_orchestration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1726,
+      "end_line": 1728,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_base_commit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1730,
+      "end_line": 1735,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#saved?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1737,
+      "end_line": 1739,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1741,
+      "end_line": 1743,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_checksums",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1745,
+      "end_line": 1747,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#jira_import_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1749,
+      "end_line": 1751,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#human_import_status_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1753,
+      "end_line": 1755,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#beautified_import_status_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1757,
+      "end_line": 1767,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#add_import_job",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1769,
+      "end_line": 1780,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#log_import_activity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1782,
+      "end_line": 1791,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#reset_cache_and_import_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1793,
+      "end_line": 1800,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#remove_import_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1803,
+      "end_line": 1805,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_config_path=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1807,
+      "end_line": 1810,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#commit_notes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1813,
+      "end_line": 1815,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#safe_import_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1827,
+      "end_line": 1830,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_url=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1832,
+      "end_line": 1844,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#unsafe_import_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1857,
+      "end_line": 1865,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#build_or_assign_import_data",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1867,
+      "end_line": 1874,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1876,
+      "end_line": 1878,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#external_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1880,
+      "end_line": 1882,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#notify_project_import_complete?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1884,
+      "end_line": 1888,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#jira_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1890,
+      "end_line": 1892,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#gitlab_project_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1894,
+      "end_line": 1896,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#gitlab_project_migration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1898,
+      "end_line": 1900,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#offline_transfer?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1902,
+      "end_line": 1904,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#transfer_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1908,
+      "end_line": 1910,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#gitea_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1912,
+      "end_line": 1914,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#github_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1916,
+      "end_line": 1918,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#bitbucket_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1920,
+      "end_line": 1922,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#bitbucket_server_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1924,
+      "end_line": 1926,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#github_enterprise_import?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1928,
+      "end_line": 1931,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#any_import_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1937,
+      "end_line": 1943,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_remote_mirror?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1945,
+      "end_line": 1947,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#updating_remote_mirror?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1949,
+      "end_line": 1951,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#update_remote_mirrors",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1953,
+      "end_line": 1957,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#mark_stuck_remote_mirrors_as_failed!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1959,
+      "end_line": 1965,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#mark_remote_mirrors_for_removal",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1967,
+      "end_line": 1969,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#remote_mirror_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1971,
+      "end_line": 1974,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#check_personal_projects_limit",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1976,
+      "end_line": 1992,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#should_validate_visibility_level?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1994,
+      "end_line": 1996,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_by_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1998,
+      "end_line": 2006,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_as_fork",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2008,
+      "end_line": 2013,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_https_only",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2015,
+      "end_line": 2019,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_https_only?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2021,
+      "end_line": 2025,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#validate_pages_https_only",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2027,
+      "end_line": 2033,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#changing_shared_runners_enabled_is_allowed",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2035,
+      "end_line": 2041,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#parent_organization_match",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2043,
+      "end_line": 2048,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#shared_runners_setting_conflicting_with_group?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2050,
+      "end_line": 2052,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#reconcile_shared_runners_setting!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2054,
+      "end_line": 2058,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#to_param",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2060,
+      "end_line": 2066,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#to_reference",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2074,
+      "end_line": 2077,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#to_reference_base",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2080,
+      "end_line": 2086,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#to_human_reference",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2088,
+      "end_line": 2094,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#readme_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2096,
+      "end_line": 2101,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#new_issuable_address",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2103,
+      "end_line": 2116,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#build_commit_note",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2118,
+      "end_line": 2120,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#last_activity",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2122,
+      "end_line": 2124,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#project_id",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2126,
+      "end_line": 2128,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#get_issue",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2130,
+      "end_line": 2138,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#issue_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2140,
+      "end_line": 2142,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#external_issue_reference_pattern",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2144,
+      "end_line": 2146,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#default_issues_tracker?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2148,
+      "end_line": 2150,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#external_issue_tracker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2152,
+      "end_line": 2158,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#external_references_supported?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2160,
+      "end_line": 2162,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_wiki?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2164,
+      "end_line": 2166,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#external_wiki",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2168,
+      "end_line": 2174,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#find_or_initialize_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2176,
+      "end_line": 2182,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#disabled_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2186,
+      "end_line": 2188,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#find_or_initialize_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2190,
+      "end_line": 2195,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#create_labels",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2198,
+      "end_line": 2206,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2209,
+      "end_line": 2211,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2213,
+      "end_line": 2215,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#avatar_in_git",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2217,
+      "end_line": 2219,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#avatar_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2221,
+      "end_line": 2223,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#code",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2226,
+      "end_line": 2228,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#all_clusters",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2230,
+      "end_line": 2235,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#items_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2237,
+      "end_line": 2244,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#send_move_instructions",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2247,
+      "end_line": 2253,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2256,
+      "end_line": 2261,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#deprecated_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2263,
+      "end_line": 2267,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#owners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2269,
+      "end_line": 2274,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#first_owner",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2276,
+      "end_line": 2284,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#execute_hooks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2287,
+      "end_line": 2292,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#triggered_hooks",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2295,
+      "end_line": 2309,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#execute_integrations",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2311,
+      "end_line": 2320,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#execute_flow_triggers",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2322,
+      "end_line": 2324,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_active_hooks?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2326,
+      "end_line": 2334,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_active_integrations?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2336,
+      "end_line": 2342,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#feature_usage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2344,
+      "end_line": 2346,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#forked?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2348,
+      "end_line": 2350,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#fork_source",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2352,
+      "end_line": 2356,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#valid_lfs_oids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2358,
+      "end_line": 2360,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_objects_for_repository_types",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2362,
+      "end_line": 2366,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_objects_oids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2368,
+      "end_line": 2370,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_objects_oids_from_fork_source",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2372,
+      "end_line": 2376,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#personal?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2378,
+      "end_line": 2380,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#expire_caches_before_rename",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2383,
+      "end_line": 2391,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#check_repository_path_availability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2394,
+      "end_line": 2408,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#track_project_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2415,
+      "end_line": 2428,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#create_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2430,
+      "end_line": 2442,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#hook_attrs",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2444,
+      "end_line": 2471,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#member",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2473,
+      "end_line": 2479,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#membership_locked?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2482,
+      "end_line": 2484,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#bots",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2486,
+      "end_line": 2488,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#members_among",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2491,
+      "end_line": 2500,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_field",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2502,
+      "end_line": 2504,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#after_repository_change_head",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2507,
+      "end_line": 2511,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#forked_from?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2513,
+      "end_line": 2515,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#in_fork_network_of?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2517,
+      "end_line": 2521,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#origin_merge_requests",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2523,
+      "end_line": 2525,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2527,
+      "end_line": 2529,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#allowed_to_share_with_group?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2532,
+      "end_line": 2534,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#share_with_group_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2536,
+      "end_line": 2538,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_successful_pipeline_for_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2540,
+      "end_line": 2547,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2549,
+      "end_line": 2551,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#builds_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2553,
+      "end_line": 2555,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#wiki_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2557,
+      "end_line": 2559,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_requests_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2561,
+      "end_line": 2563,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#forking_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2565,
+      "end_line": 2567,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#issues_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2569,
+      "end_line": 2571,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2573,
+      "end_line": 2575,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#analytics_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2577,
+      "end_line": 2579,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#snippets_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2581,
+      "end_line": 2583,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#public_pages?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2585,
+      "end_line": 2587,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#private_pages?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2589,
+      "end_line": 2594,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_access_control_forced_by_ancestor?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2596,
+      "end_line": 2600,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#operations_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2602,
+      "end_line": 2604,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#container_registry_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2606,
+      "end_line": 2608,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#enable_ci",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2611,
+      "end_line": 2613,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#shared_runners_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2615,
+      "end_line": 2617,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#shared_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2619,
+      "end_line": 2621,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#available_shared_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2623,
+      "end_line": 2625,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#group_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2627,
+      "end_line": 2629,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#all_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2631,
+      "end_line": 2633,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#all_available_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2635,
+      "end_line": 2637,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#active_runners",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2639,
+      "end_line": 2643,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#any_online_runners?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2645,
+      "end_line": 2647,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#valid_runners_token?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2649,
+      "end_line": 2651,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#open_issues_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2654,
+      "end_line": 2664,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#open_merge_requests_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2668,
+      "end_line": 2674,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_as_fork?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2677,
+      "end_line": 2684,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed_by_namespace?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2686,
+      "end_line": 2691,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visibility_level_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2693,
+      "end_line": 2695,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#runners_token",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2697,
+      "end_line": 2701,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_deployed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2703,
+      "end_line": 2705,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_show_onboarding?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2707,
+      "end_line": 2709,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_unique_domain_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2711,
+      "end_line": 2713,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#remove_private_deploy_keys",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2715,
+      "end_line": 2728,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#mark_pages_onboarding_complete",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2730,
+      "end_line": 2732,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#after_import",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2734,
+      "end_line": 2754,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#reset_counters_and_iids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2756,
+      "end_line": 2764,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#update_project_counter_caches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2766,
+      "end_line": 2776,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#after_create_default_branch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2779,
+      "end_line": 2781,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pipeline_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2785,
+      "end_line": 2787,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#add_export_job",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2789,
+      "end_line": 2803,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_export_shared",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2805,
+      "end_line": 2807,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2809,
+      "end_line": 2813,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_status",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2815,
+      "end_line": 2829,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2831,
+      "end_line": 2835,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_enqueued?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2837,
+      "end_line": 2841,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_failed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2843,
+      "end_line": 2847,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#regeneration_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2849,
+      "end_line": 2851,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#remove_exports",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2853,
+      "end_line": 2860,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#remove_export_for_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2862,
+      "end_line": 2868,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#import_export_upload_by_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2870,
+      "end_line": 2872,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_file_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2874,
+      "end_line": 2876,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_archive_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2878,
+      "end_line": 2880,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#export_file",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2882,
+      "end_line": 2884,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#full_path_slug",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2886,
+      "end_line": 2888,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_ci?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2890,
+      "end_line": 2892,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_ci_config_file?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2894,
+      "end_line": 2898,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#predefined_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2900,
+      "end_line": 2912,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#predefined_project_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2915,
+      "end_line": 2939,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#predefined_ci_server_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2942,
+      "end_line": 2959,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2961,
+      "end_line": 2969,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#api_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2971,
+      "end_line": 2976,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_template_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2978,
+      "end_line": 2982,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#dependency_proxy_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 2984,
+      "end_line": 3000,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#container_registry_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3002,
+      "end_line": 3012,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#default_environment",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3014,
+      "end_line": 3021,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#protected_for?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3023,
+      "end_line": 3040,
+      "value": 8
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#deployment_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3042,
+      "end_line": 3052,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#auto_devops_variables",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3054,
+      "end_line": 3058,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#route_map_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3060,
+      "end_line": 3072,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#public_path_for_source_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3074,
+      "end_line": 3079,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#parent_changed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3081,
+      "end_line": 3083,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#default_merge_request_target",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3085,
+      "end_line": 3090,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#mr_can_target_upstream?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3092,
+      "end_line": 3098,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#multiple_issue_boards_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3100,
+      "end_line": 3102,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#full_path_before_last_save",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3104,
+      "end_line": 3106,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#forks_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3114,
+      "end_line": 3122,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#legacy_storage?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3125,
+      "end_line": 3127,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#hashed_storage?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3132,
+      "end_line": 3136,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#archived",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3138,
+      "end_line": 3140,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_or_ancestors_archived?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3144,
+      "end_line": 3146,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_archived?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3148,
+      "end_line": 3150,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_and_ancestors_active?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3152,
+      "end_line": 3154,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_or_ancestors_transfer_scheduled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3156,
+      "end_line": 3158,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_or_ancestors_transfer_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3160,
+      "end_line": 3162,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#renamed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3164,
+      "end_line": 3166,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#human_merge_method",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3168,
+      "end_line": 3174,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_method",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3176,
+      "end_line": 3184,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#can_create_new_ref_commits?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3186,
+      "end_line": 3188,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_method=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3190,
+      "end_line": 3202,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ff_merge_must_be_possible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3204,
+      "end_line": 3206,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#git_transfer_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3209,
+      "end_line": 3213,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#storage_version=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3215,
+      "end_line": 3219,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#badges",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3221,
+      "end_line": 3225,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_requests_allowing_push_to_user",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3227,
+      "end_line": 3236,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#any_branch_allows_collaboration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3238,
+      "end_line": 3240,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#branch_allows_collaboration?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3242,
+      "end_line": 3244,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#external_authorization_classification_label",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3246,
+      "end_line": 3249,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#licensed_feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3252,
+      "end_line": 3254,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#licensed_features",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3256,
+      "end_line": 3258,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#toggle_ci_cd_settings!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3260,
+      "end_line": 3262,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#gitlab_deploy_token",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3264,
+      "end_line": 3268,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#any_lfs_file_locks?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3270,
+      "end_line": 3272,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#auto_cancel_pending_pipelines?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3275,
+      "end_line": 3277,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#storage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3279,
+      "end_line": 3286,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#snippets_visible?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3288,
+      "end_line": 3290,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#max_attachment_size",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3292,
+      "end_line": 3294,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#git_objects_poolable?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3302,
+      "end_line": 3308,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#leave_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3310,
+      "end_line": 3317,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#swap_pool_repository!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3320,
+      "end_line": 3331,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#link_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3333,
+      "end_line": 3338,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_pool_repository?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3340,
+      "end_line": 3342,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#access_request_approvers_to_be_notified",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3344,
+      "end_line": 3354,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#closest_setting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3356,
+      "end_line": 3361,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#drop_visibility_level!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3363,
+      "end_line": 3371,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#template_source?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3373,
+      "end_line": 3375,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#jira_subscription_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3377,
+      "end_line": 3379,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#group_protected_branches",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3381,
+      "end_line": 3385,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#default_branch_protected?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3387,
+      "end_line": 3391,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#environments_for_scope",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3393,
+      "end_line": 3397,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#batch_loaded_environment_by_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3399,
+      "end_line": 3408,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#latest_jira_import",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3410,
+      "end_line": 3412,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#root_namespace",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3414,
+      "end_line": 3420,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#root_group",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3422,
+      "end_line": 3426,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#related_group_ids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3428,
+      "end_line": 3434,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#default_branch_or_main",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3436,
+      "end_line": 3440,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_config_path_or_default",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3442,
+      "end_line": 3444,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_config_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3446,
+      "end_line": 3448,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#feature_flags_client_token",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3450,
+      "end_line": 3453,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#git_garbage_collect_worker_klass",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3456,
+      "end_line": 3458,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_display_pipeline_variables?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3460,
+      "end_line": 3464,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_skip_branch_pipelines_for_mrs?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3466,
+      "end_line": 3470,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_forward_deployment_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3472,
+      "end_line": 3476,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_forward_deployment_rollback_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3478,
+      "end_line": 3482,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_allow_fork_pipelines_to_run_in_parent_project?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3484,
+      "end_line": 3488,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_outbound_job_token_scope_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3490,
+      "end_line": 3494,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_inbound_job_token_scope_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3496,
+      "end_line": 3502,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#restrict_user_defined_variables?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3504,
+      "end_line": 3508,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#override_pipeline_variables_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3510,
+      "end_line": 3514,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_push_repository_for_job_token_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3516,
+      "end_line": 3520,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ci_cross_project_push_for_job_token_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3522,
+      "end_line": 3526,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#keep_latest_artifacts_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3528,
+      "end_line": 3532,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#keep_latest_artifact?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3534,
+      "end_line": 3538,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#group_runners_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3540,
+      "end_line": 3544,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#topic_list",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3546,
+      "end_line": 3548,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#after_change_head_branch_does_not_exist",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3551,
+      "end_line": 3553,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#visible_group_links",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3555,
+      "end_line": 3563,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#parent_groups",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3565,
+      "end_line": 3567,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#enforced_runner_token_expiration_interval",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3569,
+      "end_line": 3577,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_commit_template_or_default",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3579,
+      "end_line": 3581,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_commit_template_or_default=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3583,
+      "end_line": 3590,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#squash_commit_template_or_default",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3592,
+      "end_line": 3594,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#squash_commit_template_or_default=",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3596,
+      "end_line": 3603,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_deletion_in_progress?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3607,
+      "end_line": 3609,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#self_deletion_in_progress_or_hidden?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3611,
+      "end_line": 3613,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#work_item_tasks_on_boards_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3615,
+      "end_line": 3617,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#glql_load_on_click_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3619,
+      "end_line": 3621,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#markdown_placeholders_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3623,
+      "end_line": 3625,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#allow_iframes_in_markdown_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3627,
+      "end_line": 3629,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#sscs_malware_detection_feature_flag_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3631,
+      "end_line": 3633,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#use_work_item_url?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3635,
+      "end_line": 3640,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#enqueue_record_project_target_platforms",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3642,
+      "end_line": 3646,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#dormant?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3648,
+      "end_line": 3651,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#refreshing_build_artifacts_size?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3653,
+      "end_line": 3655,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#group_group_links",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3657,
+      "end_line": 3659,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#security_training_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3661,
+      "end_line": 3663,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#packages_policy_subject",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3665,
+      "end_line": 3667,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#destroy_deployment_by_id",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3669,
+      "end_line": 3671,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#can_create_custom_domains?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3673,
+      "end_line": 3677,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_domain_present?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3679,
+      "end_line": 3681,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#can_suggest_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3684,
+      "end_line": 3686,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#suggested_reviewers_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3689,
+      "end_line": 3691,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#crm_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3693,
+      "end_line": 3697,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#crm_group",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3699,
+      "end_line": 3703,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#supports_lock_on_merge?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3705,
+      "end_line": 3707,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#path_availability",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3709,
+      "end_line": 3716,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#repository_object_format",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3718,
+      "end_line": 3720,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#instance_runner_running_jobs_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3722,
+      "end_line": 3726,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#allows_multiple_merge_request_assignees?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3730,
+      "end_line": 3732,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#allows_multiple_merge_request_reviewers?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3735,
+      "end_line": 3737,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#on_demand_dast_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3740,
+      "end_line": 3742,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#supports_saved_replies?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3745,
+      "end_line": 3747,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_trains_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3750,
+      "end_line": 3752,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_file_locks_changed_epoch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3754,
+      "end_line": 3756,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#refresh_lfs_file_locks_changed_epoch",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3758,
+      "end_line": 3760,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#placeholder_reference_store",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3762,
+      "end_line": 3769,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_url",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3771,
+      "end_line": 3773,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_hostname",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3775,
+      "end_line": 3777,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#uploads_sharding_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3779,
+      "end_line": 3781,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pages_url_builder",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3783,
+      "end_line": 3787,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_container_registry_protected_tag_rules?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3789,
+      "end_line": 3793,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#licensed_ai_features_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3796,
+      "end_line": 3798,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3801,
+      "end_line": 3803,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#check_duplicate_export!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3807,
+      "end_line": 3811,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#with_redis",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3813,
+      "end_line": 3815,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#lfs_file_locks_changed_epoch_cache_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3817,
+      "end_line": 3819,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#get_epoch_from",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3821,
+      "end_line": 3823,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#refresh_epoch_cache",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3825,
+      "end_line": 3831,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#project_group_links_with_preload",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3834,
+      "end_line": 3836,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#save_topics",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3838,
+      "end_line": 3842,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#update_topics",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3844,
+      "end_line": 3862,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#find_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3864,
+      "end_line": 3866,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#build_from_instance",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3868,
+      "end_line": 3874,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#build_integration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3876,
+      "end_line": 3878,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#integration_instances",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3880,
+      "end_line": 3882,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#closest_namespace_setting",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3884,
+      "end_line": 3886,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#app_settings_for",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3888,
+      "end_line": 3890,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#merge_requests_allowing_collaboration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3892,
+      "end_line": 3896,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#create_new_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3898,
+      "end_line": 3910,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#join_pool_repository",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3912,
+      "end_line": 3916,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#use_hashed_storage",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3918,
+      "end_line": 3922,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#check_repository_absence!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3924,
+      "end_line": 3931,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#repository_with_same_path_already_exists?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3933,
+      "end_line": 3935,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#set_timestamps_for_create",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3937,
+      "end_line": 3939,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#cross_namespace_reference?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3941,
+      "end_line": 3952,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#cross_project_reference?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3955,
+      "end_line": 3964,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#update_project_statistics",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3966,
+      "end_line": 3969,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#check_pending_delete",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3971,
+      "end_line": 3980,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pending_delete_twin",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3982,
+      "end_line": 3986,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#has_root_container_repository_tags?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3993,
+      "end_line": 3997,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#fetch_branch_allows_collaboration",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 3999,
+      "end_line": 4013,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_pages_metadatum",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4015,
+      "end_line": 4020,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#oids",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4022,
+      "end_line": 4028,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#cache_has_external_wiki",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4030,
+      "end_line": 4032,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#cache_has_external_issue_tracker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4034,
+      "end_line": 4036,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#online_runners_with_tags",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4038,
+      "end_line": 4040,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ensure_project_namespace_in_sync",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4042,
+      "end_line": 4047,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#project_namespace_creation_enabled?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4049,
+      "end_line": 4051,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#sync_project_namespace?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4053,
+      "end_line": 4055,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#reload_project_namespace_details",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4057,
+      "end_line": 4061,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#schedule_sync_event_worker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4064,
+      "end_line": 4068,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#check_project_export_limit!",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4070,
+      "end_line": 4076,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#remove_leading_spaces_on_name",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4078,
+      "end_line": 4080,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#set_last_activity_at",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4082,
+      "end_line": 4090,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#set_package_registry_access_level",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4092,
+      "end_line": 4096,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#enabled_package_registry_access_level_by_project_visibility",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4098,
+      "end_line": 4107,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#runners_token_prefix",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4109,
+      "end_line": 4111,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#pool_repository_shard_matches_repository?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4113,
+      "end_line": 4117,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#enqueue_catalog_resource_sync_event_worker",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4120,
+      "end_line": 4124,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#ancestors_scheduled_for_deletion",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4128,
+      "end_line": 4136,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#validate_unsafe_import_url?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4138,
+      "end_line": 4140,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Project#unique_attributes",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 4142,
+      "end_line": 4144,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Project",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 5,
+      "end_line": 4145,
+      "value": 3081
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "singleton_class",
+      "scope_name": "class << Project",
+      "path": "spec/fixtures/corpus/gitlab/app/models/project.rb",
+      "start_line": 1243,
+      "end_line": 1414,
+      "value": 129
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/models/release_highlight.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/models/release_highlight.rb.json
@@ -1,0 +1,404 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 14,
+        "max": 18.49,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.load_items",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 28,
+            "end_line": 54,
+            "value": 18.49
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.relative_file_paths",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 64,
+            "end_line": 71,
+            "value": 12.53
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.most_recent_version_digest",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 104,
+            "end_line": 114,
+            "value": 11.83
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.release_date_reached?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 73,
+            "end_line": 82,
+            "value": 10.86
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.include_item?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 135,
+            "end_line": 143,
+            "value": 8.12
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 14,
+        "max": 7,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.load_items",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 28,
+            "end_line": 54,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.most_recent_version_digest",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 104,
+            "end_line": 114,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.current_package",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 122,
+            "end_line": 133,
+            "value": 6
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.include_item?",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 135,
+            "end_line": 143,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ReleaseHighlight.relative_file_paths",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 64,
+            "end_line": 71,
+            "value": 4
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 108,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "ReleaseHighlight",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 3,
+            "end_line": 152,
+            "value": 108
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "ReleaseHighlight::QueryResult",
+            "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+            "start_line": 116,
+            "end_line": 120,
+            "value": 2
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.paginated",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 10,
+      "end_line": 14,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.paginated_query",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 16,
+      "end_line": 26,
+      "value": 7.55
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.load_items",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 28,
+      "end_line": 54,
+      "value": 18.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.whats_new_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 56,
+      "end_line": 58,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.file_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 60,
+      "end_line": 62,
+      "value": 5.74
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.relative_file_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 64,
+      "end_line": 71,
+      "value": 12.53
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.release_date_reached?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 73,
+      "end_line": 82,
+      "value": 10.86
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.cache_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 84,
+      "end_line": 87,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.next_page",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 89,
+      "end_line": 94,
+      "value": 4.58
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.most_recent_item_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 96,
+      "end_line": 102,
+      "value": 6.78
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.most_recent_version_digest",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 104,
+      "end_line": 114,
+      "value": 11.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.current_package",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 122,
+      "end_line": 133,
+      "value": 5.83
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.include_item?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 135,
+      "end_line": 143,
+      "value": 8.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.next_page?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 145,
+      "end_line": 151,
+      "value": 4.24
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.paginated",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 10,
+      "end_line": 14,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.paginated_query",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 16,
+      "end_line": 26,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.load_items",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 28,
+      "end_line": 54,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.whats_new_path",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 56,
+      "end_line": 58,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.file_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 60,
+      "end_line": 62,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.relative_file_paths",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 64,
+      "end_line": 71,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.release_date_reached?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 73,
+      "end_line": 82,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.cache_key",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 84,
+      "end_line": 87,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.next_page",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 89,
+      "end_line": 94,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.most_recent_item_count",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 96,
+      "end_line": 102,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.most_recent_version_digest",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 104,
+      "end_line": 114,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.current_package",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 122,
+      "end_line": 133,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.include_item?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 135,
+      "end_line": 143,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ReleaseHighlight.next_page?",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 145,
+      "end_line": 151,
+      "value": 3
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "ReleaseHighlight",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 3,
+      "end_line": 152,
+      "value": 108
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "ReleaseHighlight::QueryResult",
+      "path": "spec/fixtures/corpus/gitlab/app/models/release_highlight.rb",
+      "start_line": 116,
+      "end_line": 120,
+      "value": 2
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/policies/project_policy.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/policies/project_policy.rb.json
@@ -1,0 +1,332 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 11,
+        "max": 15.26,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#team_member?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 966,
+            "end_line": 991,
+            "value": 15.26
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#access_allowed_to?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 1024,
+            "end_line": 1039,
+            "value": 12.21
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#project_group_requester?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 1001,
+            "end_line": 1006,
+            "value": 9.49
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#project_group_member?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 993,
+            "end_line": 998,
+            "value": 7.62
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#cross_project_push_allowed_for_job_token?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 1057,
+            "end_line": 1061,
+            "value": 7.28
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 11,
+        "max": 7,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#access_allowed_to?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 1024,
+            "end_line": 1039,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#team_member?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 966,
+            "end_line": 991,
+            "value": 6
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#project_group_member?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 993,
+            "end_line": 998,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#project_group_requester?",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 1001,
+            "end_line": 1006,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "ProjectPolicy#team_access_level",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 1009,
+            "end_line": 1014,
+            "value": 4
+          }
+        ]
+      },
+      "class_length": {
+        "count": 1,
+        "max": 802,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "ProjectPolicy",
+            "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+            "start_line": 3,
+            "end_line": 1066,
+            "value": 802
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#team_member?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 966,
+      "end_line": 991,
+      "value": 15.26
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#project_group_member?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 993,
+      "end_line": 998,
+      "value": 7.62
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#project_group_requester?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1001,
+      "end_line": 1006,
+      "value": 9.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#team_access_level",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1009,
+      "end_line": 1014,
+      "value": 4.69
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#lookup_access_level!",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1017,
+      "end_line": 1022,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#access_allowed_to?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1024,
+      "end_line": 1039,
+      "value": 12.21
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#resource_access_token_feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1041,
+      "end_line": 1043,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#resource_access_token_create_feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1045,
+      "end_line": 1047,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#resource_access_token_creation_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1049,
+      "end_line": 1055,
+      "value": 6.4
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#cross_project_push_allowed_for_job_token?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1057,
+      "end_line": 1061,
+      "value": 7.28
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#project",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1063,
+      "end_line": 1065,
+      "value": 0.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#team_member?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 966,
+      "end_line": 991,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#project_group_member?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 993,
+      "end_line": 998,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#project_group_requester?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1001,
+      "end_line": 1006,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#team_access_level",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1009,
+      "end_line": 1014,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#lookup_access_level!",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1017,
+      "end_line": 1022,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#access_allowed_to?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1024,
+      "end_line": 1039,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#resource_access_token_feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1041,
+      "end_line": 1043,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#resource_access_token_create_feature_available?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1045,
+      "end_line": 1047,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#resource_access_token_creation_allowed?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1049,
+      "end_line": 1055,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#cross_project_push_allowed_for_job_token?",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1057,
+      "end_line": 1061,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "ProjectPolicy#project",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 1063,
+      "end_line": 1065,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "ProjectPolicy",
+      "path": "spec/fixtures/corpus/gitlab/app/policies/project_policy.rb",
+      "start_line": 3,
+      "end_line": 1066,
+      "value": 802
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/services/ci/create_pipeline_service.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/services/ci/create_pipeline_service.rb.json
@@ -1,0 +1,296 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 8,
+        "max": 83.17,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#execute",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 67,
+            "end_line": 144,
+            "value": 83.17
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#execute_async",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 147,
+            "end_line": 157,
+            "value": 17.12
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#build_logger",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 186,
+            "end_line": 209,
+            "value": 16.03
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#recover_pipeline_iid",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 169,
+            "end_line": 172,
+            "value": 4.12
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#validate_options!",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 176,
+            "end_line": 178,
+            "value": 3.16
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 8,
+        "max": 12,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#execute",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 67,
+            "end_line": 144,
+            "value": 12
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#build_logger",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 186,
+            "end_line": 209,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#recover_pipeline_iid",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 169,
+            "end_line": 172,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#validate_options!",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 176,
+            "end_line": 178,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Ci::CreatePipelineService#execute_async",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 147,
+            "end_line": 157,
+            "value": 1
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 152,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Ci::CreatePipelineService",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 4,
+            "end_line": 210,
+            "value": 152
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Ci",
+            "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+            "start_line": 3,
+            "end_line": 211,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#execute",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 67,
+      "end_line": 144,
+      "value": 83.17
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#execute_async",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 147,
+      "end_line": 157,
+      "value": 17.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#yaml_processor_result",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 159,
+      "end_line": 161,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#after_successful_creation_hook",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 165,
+      "end_line": 167,
+      "value": 0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#recover_pipeline_iid",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 169,
+      "end_line": 172,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#validate_options!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 176,
+      "end_line": 178,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#extra_options",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 182,
+      "end_line": 184,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#build_logger",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 186,
+      "end_line": 209,
+      "value": 16.03
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#execute",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 67,
+      "end_line": 144,
+      "value": 12
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#execute_async",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 147,
+      "end_line": 157,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#yaml_processor_result",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 159,
+      "end_line": 161,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#after_successful_creation_hook",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 165,
+      "end_line": 167,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#recover_pipeline_iid",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 169,
+      "end_line": 172,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#validate_options!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 176,
+      "end_line": 178,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#extra_options",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 182,
+      "end_line": 184,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Ci::CreatePipelineService#build_logger",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 186,
+      "end_line": 209,
+      "value": 5
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Ci",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 3,
+      "end_line": 211,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Ci::CreatePipelineService",
+      "path": "spec/fixtures/corpus/gitlab/app/services/ci/create_pipeline_service.rb",
+      "start_line": 4,
+      "end_line": 210,
+      "value": 152
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/app/services/merge_requests/create_service.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/app/services/merge_requests/create_service.rb.json
@@ -1,0 +1,278 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 7,
+        "max": 14.46,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#set_projects!",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 58,
+            "end_line": 76,
+            "value": 14.46
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#execute",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 5,
+            "end_line": 21,
+            "value": 14.32
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#set_default_attributes!",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 78,
+            "end_line": 81,
+            "value": 9.49
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#after_create",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 23,
+            "end_line": 37,
+            "value": 7.07
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#before_create",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 45,
+            "end_line": 56,
+            "value": 5.1
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 7,
+        "max": 4,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#set_projects!",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 58,
+            "end_line": 76,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#set_default_attributes!",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 78,
+            "end_line": 81,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#execute",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 5,
+            "end_line": 21,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#after_create",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 23,
+            "end_line": 37,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "MergeRequests::CreateService#before_create",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 45,
+            "end_line": 56,
+            "value": 1
+          }
+        ]
+      },
+      "class_length": {
+        "count": 2,
+        "max": 49,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "MergeRequests::CreateService",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 4,
+            "end_line": 90,
+            "value": 49
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "MergeRequests",
+            "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+            "start_line": 3,
+            "end_line": 91,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#execute",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 5,
+      "end_line": 21,
+      "value": 14.32
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#after_create",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 23,
+      "end_line": 37,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#before_create",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 45,
+      "end_line": 56,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_projects!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 58,
+      "end_line": 76,
+      "value": 14.46
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_default_attributes!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 78,
+      "end_line": 81,
+      "value": 9.49
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_default_force_remove_source_branch!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 83,
+      "end_line": 85,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_default_squash!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 87,
+      "end_line": 89,
+      "value": 3.16
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#execute",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 5,
+      "end_line": 21,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#after_create",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 23,
+      "end_line": 37,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#before_create",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 45,
+      "end_line": 56,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_projects!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 58,
+      "end_line": 76,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_default_attributes!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 78,
+      "end_line": 81,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_default_force_remove_source_branch!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 83,
+      "end_line": 85,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "MergeRequests::CreateService#set_default_squash!",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 87,
+      "end_line": 89,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "MergeRequests",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 3,
+      "end_line": 91,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "MergeRequests::CreateService",
+      "path": "spec/fixtures/corpus/gitlab/app/services/merge_requests/create_service.rb",
+      "start_line": 4,
+      "end_line": 90,
+      "value": 49
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/config/routes.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/config/routes.rb.json
@@ -1,0 +1,56 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 1,
+        "max": 217.26,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "draw_all_routes",
+            "path": "spec/fixtures/corpus/gitlab/config/routes.rb",
+            "start_line": 9,
+            "end_line": 375,
+            "value": 217.26
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 1,
+        "max": 7,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "draw_all_routes",
+            "path": "spec/fixtures/corpus/gitlab/config/routes.rb",
+            "start_line": 9,
+            "end_line": 375,
+            "value": 7
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "draw_all_routes",
+      "path": "spec/fixtures/corpus/gitlab/config/routes.rb",
+      "start_line": 9,
+      "end_line": 375,
+      "value": 217.26
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "draw_all_routes",
+      "path": "spec/fixtures/corpus/gitlab/config/routes.rb",
+      "start_line": 9,
+      "end_line": 375,
+      "value": 7
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb.json
@@ -1,0 +1,332 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 9,
+        "max": 9.0,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#delete_and_archive_award_emoji_with_no_sharding_key",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 112,
+            "end_line": 126,
+            "value": 9.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#perform",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 9,
+            "end_line": 18,
+            "value": 7.07
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#common_query",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 22,
+            "end_line": 31,
+            "value": 5.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_note_related_records",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 87,
+            "end_line": 110,
+            "value": 4.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_issue_related_records",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 33,
+            "end_line": 44,
+            "value": 3.0
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 9,
+        "max": 2,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#award_emoji_columns_for_archive",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 128,
+            "end_line": 132,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#perform",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 9,
+            "end_line": 18,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#common_query",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 22,
+            "end_line": 31,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_issue_related_records",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 33,
+            "end_line": 44,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_merge_request_related_records",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 46,
+            "end_line": 58,
+            "value": 1
+          }
+        ]
+      },
+      "class_length": {
+        "count": 3,
+        "max": 114,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 5,
+            "end_line": 133,
+            "value": 114
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 3,
+            "end_line": 135,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::BackgroundMigration",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+            "start_line": 4,
+            "end_line": 134,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#perform",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 9,
+      "end_line": 18,
+      "value": 7.07
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#common_query",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 22,
+      "end_line": 31,
+      "value": 5.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_issue_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 33,
+      "end_line": 44,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_merge_request_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 46,
+      "end_line": 58,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_epic_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 60,
+      "end_line": 71,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_snippet_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 73,
+      "end_line": 85,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_note_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 87,
+      "end_line": 110,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#delete_and_archive_award_emoji_with_no_sharding_key",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 112,
+      "end_line": 126,
+      "value": 9.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#award_emoji_columns_for_archive",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 128,
+      "end_line": 132,
+      "value": 2.45
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#perform",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 9,
+      "end_line": 18,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#common_query",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 22,
+      "end_line": 31,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_issue_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 33,
+      "end_line": 44,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_merge_request_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 46,
+      "end_line": 58,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_epic_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 60,
+      "end_line": 71,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_snippet_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 73,
+      "end_line": 85,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#handle_note_related_records",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 87,
+      "end_line": 110,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#delete_and_archive_award_emoji_with_no_sharding_key",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 112,
+      "end_line": 126,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey#award_emoji_columns_for_archive",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 128,
+      "end_line": 132,
+      "value": 2
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 3,
+      "end_line": 135,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::BackgroundMigration",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 4,
+      "end_line": 134,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::BackgroundMigration::BackfillAwardEmojiShardingKey",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/background_migration/backfill_award_emoji_sharding_key.rb",
+      "start_line": 5,
+      "end_line": 133,
+      "value": 114
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/lib/gitlab/ci/config/entry/job.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/lib/gitlab/ci/config/entry/job.rb.json
@@ -1,0 +1,422 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 12,
+        "max": 33.38,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#value",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 186,
+            "end_line": 216,
+            "value": 33.38
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#artifacts_with_pages_publish_path",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 234,
+            "end_line": 243,
+            "value": 11.87
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_publish_path",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 263,
+            "end_line": 269,
+            "value": 7.68
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_job?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 228,
+            "end_line": 232,
+            "value": 7.21
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job.matching?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 174,
+            "end_line": 176,
+            "value": 6.71
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 12,
+        "max": 6,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#value",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 186,
+            "end_line": 216,
+            "value": 6
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#artifacts_with_pages_publish_path",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 234,
+            "end_line": 243,
+            "value": 5
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job.matching?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 174,
+            "end_line": 176,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_publish_path",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 263,
+            "end_line": 269,
+            "value": 4
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_job?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 228,
+            "end_line": 232,
+            "value": 3
+          }
+        ]
+      },
+      "class_length": {
+        "count": 5,
+        "max": 201,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::Ci::Config::Entry::Job",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 10,
+            "end_line": 270,
+            "value": 201
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 3,
+            "end_line": 274,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 4,
+            "end_line": 273,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::Ci::Config",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 5,
+            "end_line": 272,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci::Config::Entry",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+            "start_line": 6,
+            "end_line": 271,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job.matching?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 174,
+      "end_line": 176,
+      "value": 6.71
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job.visible?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 178,
+      "end_line": 180,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#delayed?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 182,
+      "end_line": 184,
+      "value": 1.41
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#value",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 186,
+      "end_line": 216,
+      "value": 33.38
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#parsed_timeout",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 218,
+      "end_line": 222,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#ignored?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 224,
+      "end_line": 226,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_job?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 228,
+      "end_line": 232,
+      "value": 7.21
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#artifacts_with_pages_publish_path",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 234,
+      "end_line": 243,
+      "value": 11.87
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job.allowed_keys",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 245,
+      "end_line": 247,
+      "value": 0.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#allow_failure_criteria",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 251,
+      "end_line": 255,
+      "value": 4.47
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#static_allow_failure",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 257,
+      "end_line": 261,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_publish_path",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 263,
+      "end_line": 269,
+      "value": 7.68
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job.matching?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 174,
+      "end_line": 176,
+      "value": 4
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job.visible?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 178,
+      "end_line": 180,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#delayed?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 182,
+      "end_line": 184,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#value",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 186,
+      "end_line": 216,
+      "value": 6
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#parsed_timeout",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 218,
+      "end_line": 222,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#ignored?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 224,
+      "end_line": 226,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_job?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 228,
+      "end_line": 232,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#artifacts_with_pages_publish_path",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 234,
+      "end_line": 243,
+      "value": 5
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job.allowed_keys",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 245,
+      "end_line": 247,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#allow_failure_criteria",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 251,
+      "end_line": 255,
+      "value": 3
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#static_allow_failure",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 257,
+      "end_line": 261,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job#pages_publish_path",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 263,
+      "end_line": 269,
+      "value": 4
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 3,
+      "end_line": 274,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 4,
+      "end_line": 273,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::Ci::Config",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 5,
+      "end_line": 272,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci::Config::Entry",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 6,
+      "end_line": 271,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::Ci::Config::Entry::Job",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/job.rb",
+      "start_line": 10,
+      "end_line": 270,
+      "value": 201
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/lib/gitlab/ci/config/entry/rules.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/lib/gitlab/ci/config/entry/rules.rb.json
@@ -1,0 +1,188 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 2,
+        "max": 1.0,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Rules#value",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 15,
+            "end_line": 17,
+            "value": 1.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Rules#composable_class",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 19,
+            "end_line": 21,
+            "value": 0.0
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 2,
+        "max": 1,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Rules#value",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 15,
+            "end_line": 17,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Config::Entry::Rules#composable_class",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 19,
+            "end_line": 21,
+            "value": 1
+          }
+        ]
+      },
+      "class_length": {
+        "count": 5,
+        "max": 11,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::Ci::Config::Entry::Rules",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 7,
+            "end_line": 22,
+            "value": 11
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 3,
+            "end_line": 26,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 4,
+            "end_line": 25,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::Ci::Config",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 5,
+            "end_line": 24,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci::Config::Entry",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+            "start_line": 6,
+            "end_line": 23,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Rules#value",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 15,
+      "end_line": 17,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Rules#composable_class",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 19,
+      "end_line": 21,
+      "value": 0.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Rules#value",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 15,
+      "end_line": 17,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Config::Entry::Rules#composable_class",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 19,
+      "end_line": 21,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 3,
+      "end_line": 26,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 4,
+      "end_line": 25,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::Ci::Config",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 5,
+      "end_line": 24,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci::Config::Entry",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 6,
+      "end_line": 23,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::Ci::Config::Entry::Rules",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/config/entry/rules.rb",
+      "start_line": 7,
+      "end_line": 22,
+      "value": 11
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb.json
@@ -1,0 +1,341 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 7,
+        "max": 23.77,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#perform!",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 15,
+            "end_line": 44,
+            "value": 23.77
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_write_ref?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 60,
+            "end_line": 77,
+            "value": 20.12
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#push_from_ci?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 84,
+            "end_line": 86,
+            "value": 4.12
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_create_pipeline?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 52,
+            "end_line": 54,
+            "value": 3.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#user_access",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 79,
+            "end_line": 81,
+            "value": 3.0
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 7,
+        "max": 9,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_write_ref?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 60,
+            "end_line": 77,
+            "value": 9
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#perform!",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 15,
+            "end_line": 44,
+            "value": 7
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#push_from_ci?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 84,
+            "end_line": 86,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#break?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 46,
+            "end_line": 48,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_create_pipeline?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 52,
+            "end_line": 54,
+            "value": 1
+          }
+        ]
+      },
+      "class_length": {
+        "count": 6,
+        "max": 59,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 8,
+            "end_line": 87,
+            "value": 59
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 3,
+            "end_line": 92,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 4,
+            "end_line": 91,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci::Pipeline",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 5,
+            "end_line": 90,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Ci::Pipeline::Chain",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+            "start_line": 6,
+            "end_line": 89,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#perform!",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 15,
+      "end_line": 44,
+      "value": 23.77
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#break?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 46,
+      "end_line": 48,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_create_pipeline?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 52,
+      "end_line": 54,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_run_pipeline?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 56,
+      "end_line": 58,
+      "value": 1.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_write_ref?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 60,
+      "end_line": 77,
+      "value": 20.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#user_access",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 79,
+      "end_line": 81,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#push_from_ci?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 84,
+      "end_line": 86,
+      "value": 4.12
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#perform!",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 15,
+      "end_line": 44,
+      "value": 7
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#break?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 46,
+      "end_line": 48,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_create_pipeline?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 52,
+      "end_line": 54,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_run_pipeline?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 56,
+      "end_line": 58,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#allowed_to_write_ref?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 60,
+      "end_line": 77,
+      "value": 9
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#user_access",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 79,
+      "end_line": 81,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities#push_from_ci?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 84,
+      "end_line": 86,
+      "value": 2
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 3,
+      "end_line": 92,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 4,
+      "end_line": 91,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci::Pipeline",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 5,
+      "end_line": 90,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 6,
+      "end_line": 89,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 7,
+      "end_line": 88,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::Ci::Pipeline::Chain::Validate::Abilities",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/ci/pipeline/chain/validate/abilities.rb",
+      "start_line": 8,
+      "end_line": 87,
+      "value": 59
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb.json
@@ -1,0 +1,368 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 9,
+        "max": 5.1,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#execute_with_lock",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 26,
+            "end_line": 33,
+            "value": 5.1
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#set_lock",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 39,
+            "end_line": 43,
+            "value": 4.12
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#log",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 55,
+            "end_line": 57,
+            "value": 4.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.backoff_runner?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 15,
+            "end_line": 19,
+            "value": 3.16
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#remove_lock",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 45,
+            "end_line": 49,
+            "value": 3.0
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 9,
+        "max": 2,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.backoff_runner?",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 15,
+            "end_line": 19,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#execute_with_lock",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 26,
+            "end_line": 33,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#set_lock",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 39,
+            "end_line": 43,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#exclusive_lease",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 51,
+            "end_line": 53,
+            "value": 2
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.execute_with_lock",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 11,
+            "end_line": 13,
+            "value": 1
+          }
+        ]
+      },
+      "class_length": {
+        "count": 5,
+        "max": 39,
+        "top_hotspots": [
+          {
+            "metric": "class_length",
+            "scope_type": "class",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 7,
+            "end_line": 62,
+            "value": 39
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 3,
+            "end_line": 66,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Database",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 4,
+            "end_line": 65,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Database::Migrations",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 5,
+            "end_line": 64,
+            "value": 0
+          },
+          {
+            "metric": "class_length",
+            "scope_type": "module",
+            "scope_name": "Gitlab::Database::Migrations::RunnerBackoff",
+            "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+            "start_line": 6,
+            "end_line": 63,
+            "value": 0
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.execute_with_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 11,
+      "end_line": 13,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.backoff_runner?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 15,
+      "end_line": 19,
+      "value": 3.16
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#initialize",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 21,
+      "end_line": 24,
+      "value": 2.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#execute_with_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 26,
+      "end_line": 33,
+      "value": 5.1
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#set_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 39,
+      "end_line": 43,
+      "value": 4.12
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#remove_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 45,
+      "end_line": 49,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#exclusive_lease",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 51,
+      "end_line": 53,
+      "value": 2.45
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#log",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 55,
+      "end_line": 57,
+      "value": 4.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#log_params",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 59,
+      "end_line": 61,
+      "value": 2.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.execute_with_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 11,
+      "end_line": 13,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator.backoff_runner?",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 15,
+      "end_line": 19,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#initialize",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 21,
+      "end_line": 24,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#execute_with_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 26,
+      "end_line": 33,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#set_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 39,
+      "end_line": 43,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#remove_lock",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 45,
+      "end_line": 49,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#exclusive_lease",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 51,
+      "end_line": 53,
+      "value": 2
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#log",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 55,
+      "end_line": 57,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator#log_params",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 59,
+      "end_line": 61,
+      "value": 1
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 3,
+      "end_line": 66,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Database",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 4,
+      "end_line": 65,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Database::Migrations",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 5,
+      "end_line": 64,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "module",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 6,
+      "end_line": 63,
+      "value": 0
+    },
+    {
+      "metric": "class_length",
+      "scope_type": "class",
+      "scope_name": "Gitlab::Database::Migrations::RunnerBackoff::Communicator",
+      "path": "spec/fixtures/corpus/gitlab/lib/gitlab/database/migrations/runner_backoff/communicator.rb",
+      "start_line": 7,
+      "end_line": 62,
+      "value": 39
+    }
+  ]
+}

--- a/spec/fixtures/golden_reports/gitlab/spec/models/ability_spec.rb.json
+++ b/spec/fixtures/golden_reports/gitlab/spec/models/ability_spec.rb.json
@@ -1,0 +1,92 @@
+{
+  "summary": {
+    "metrics": {
+      "abc_metric": {
+        "count": 2,
+        "max": 6.0,
+        "top_hotspots": [
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "check_ability",
+            "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+            "start_line": 638,
+            "end_line": 640,
+            "value": 6.0
+          },
+          {
+            "metric": "abc_metric",
+            "scope_type": "method",
+            "scope_name": "users_for_snippet",
+            "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+            "start_line": 167,
+            "end_line": 169,
+            "value": 3.0
+          }
+        ]
+      },
+      "cyclomatic_complexity": {
+        "count": 2,
+        "max": 1,
+        "top_hotspots": [
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "users_for_snippet",
+            "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+            "start_line": 167,
+            "end_line": 169,
+            "value": 1
+          },
+          {
+            "metric": "cyclomatic_complexity",
+            "scope_type": "method",
+            "scope_name": "check_ability",
+            "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+            "start_line": 638,
+            "end_line": 640,
+            "value": 1
+          }
+        ]
+      }
+    }
+  },
+  "measurements": [
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "users_for_snippet",
+      "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+      "start_line": 167,
+      "end_line": 169,
+      "value": 3.0
+    },
+    {
+      "metric": "abc_metric",
+      "scope_type": "method",
+      "scope_name": "check_ability",
+      "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+      "start_line": 638,
+      "end_line": 640,
+      "value": 6.0
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "users_for_snippet",
+      "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+      "start_line": 167,
+      "end_line": 169,
+      "value": 1
+    },
+    {
+      "metric": "cyclomatic_complexity",
+      "scope_type": "method",
+      "scope_name": "check_ability",
+      "path": "spec/fixtures/corpus/gitlab/spec/models/ability_spec.rb",
+      "start_line": 638,
+      "end_line": 640,
+      "value": 1
+    }
+  ]
+}

--- a/spec/support/corpus_golden_report.rb
+++ b/spec/support/corpus_golden_report.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+
+# Generates and locates committed CodeKeeper JSON reports for the corpus.
+module CorpusGoldenReport
+  ROOT = "spec/fixtures/golden_reports/gitlab"
+
+  module_function
+
+  def snapshot_paths
+    CorpusReportRunner.file_paths.map { |path| snapshot_path_for(path) }
+  end
+
+  def snapshot_path_for(corpus_path)
+    relative_path = corpus_path.delete_prefix("#{CorpusReportRunner::ROOT}/")
+
+    File.join(ROOT, "#{relative_path}.json")
+  end
+
+  def serialized_report_for(corpus_path)
+    "#{JSON.pretty_generate(report_hash_for(corpus_path))}\n"
+  end
+
+  def regenerate_all
+    prune_stale_snapshots
+
+    CorpusReportRunner.file_paths.each do |corpus_path|
+      snapshot_path = snapshot_path_for(corpus_path)
+      FileUtils.mkdir_p(File.dirname(snapshot_path))
+      File.write(snapshot_path, serialized_report_for(corpus_path))
+    end
+  end
+
+  def prune_stale_snapshots
+    FileUtils.rm_f(stale_snapshot_paths)
+  end
+
+  def stale_snapshot_paths(existing_paths: Dir[File.join(ROOT, "**/*.json")])
+    existing_paths - snapshot_paths
+  end
+
+  def report_hash_for(corpus_path)
+    CorpusReportRunner.report_for(corpus_path, number_of_threads: 1).to_h
+  end
+end


### PR DESCRIPTION
## Purpose

Refs #41. This is stacked on #44 and implements the third PR-plan slice: committed golden reports and an out-of-band regeneration task.

## Changes

- Commit one pretty-printed CodeKeeper JSON report per vendored GitLab corpus file under `spec/fixtures/golden_reports/gitlab/`.
- Generate reports through the existing corpus runner using repository-relative corpus paths, so snapshot paths do not depend on the execution environment.
- Add RSpec coverage that verifies one snapshot exists per corpus file, snapshots match current CodeKeeper output, and every recorded report path is repository-relative.
- Add `bundle exec rake corpus:regenerate_golden_reports` as the explicit regeneration task.
- Document the snapshot location and regeneration procedure in the corpus README.

## Impact

This is test-only. Runtime library behavior is unchanged. The regeneration task is not part of CI; CI only verifies the committed snapshots.

## Verification

- `bundle exec rake corpus:regenerate_golden_reports`
- `bundle exec rspec` - 80 examples, 0 failures
- `bundle exec rubocop` - 41 files inspected, no offenses
- `git diff --check` - no whitespace errors

## Scope Out

- Full-repository sweeps
- Additional corpus selection
- RuboCop differential changes beyond the stack base